### PR TITLE
Simplify class_interface_clause

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -222,10 +222,7 @@ module.exports = grammar({
       'extends', $.qualified_name
     ),
 
-    class_interface_clause: $ => choice(
-      seq('implements', $.qualified_name),
-      seq($.class_interface_clause, ',', $.qualified_name)
-    ),
+    class_interface_clause: $ => seq('implements', commaSep1($.qualified_name)),
 
     _class_member_declaration: $ => choice(
       $.class_const_declaration,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1045,35 +1045,34 @@
       ]
     },
     "class_interface_clause": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "implements"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "qualified_name"
-            }
-          ]
+          "type": "STRING",
+          "value": "implements"
         },
         {
           "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "class_interface_clause"
-            },
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "SYMBOL",
               "name": "qualified_name"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "qualified_name"
+                  }
+                ]
+              }
             }
           ]
         }


### PR DESCRIPTION
Use `commaSep1` instead of declaring `class_interface_clause` recursively.