### PR TITLE
Add a conflict for namespace_name_as_prefix

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -38,6 +38,9 @@ module.exports = grammar({
     [$.qualified_name, $.namespace_name],
     [$.namespace_name],
     [$.namespace_aliasing_clause, $.name],
+
+    [$.namespace_name_as_prefix],
+    [$.namespace_use_declaration, $.namespace_name_as_prefix]
   ],
   inline: $ => [
     $._statement,
@@ -154,12 +157,12 @@ module.exports = grammar({
       optional($.namespace_name_as_prefix), $.name
     ),
 
-    namespace_name_as_prefix: $ => prec.right(choice(
+    namespace_name_as_prefix: $ => choice(
       '\\',
       seq(optional('\\'), $.namespace_name, '\\'),
       seq('namespace', '\\'),
       seq('namespace', optional('\\'), $.namespace_name, '\\')
-    )),
+    ),
 
     namespace_name: $ => seq($.name, repeat(seq('\\', $.name))),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -624,84 +624,80 @@
       ]
     },
     "namespace_name_as_prefix": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "\\"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "\\"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "namespace_name"
-              },
-              {
-                "type": "STRING",
-                "value": "\\"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "namespace"
-              },
-              {
-                "type": "STRING",
-                "value": "\\"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "namespace"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "\\"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "namespace_name"
-              },
-              {
-                "type": "STRING",
-                "value": "\\"
-              }
-            ]
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "namespace_name"
+            },
+            {
+              "type": "STRING",
+              "value": "\\"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "namespace"
+            },
+            {
+              "type": "STRING",
+              "value": "\\"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "namespace"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "namespace_name"
+            },
+            {
+              "type": "STRING",
+              "value": "\\"
+            }
+          ]
+        }
+      ]
     },
     "namespace_name": {
       "type": "SEQ",
@@ -6695,6 +6691,13 @@
     [
       "namespace_aliasing_clause",
       "name"
+    ],
+    [
+      "namespace_name_as_prefix"
+    ],
+    [
+      "namespace_use_declaration",
+      "namespace_name_as_prefix"
     ]
   ],
   "externals": [


### PR DESCRIPTION
This fixes an issue where a `namespace_name_as_prefix` with a preceding slash within a `simple_parameter` would fail to parse:

```php
<?php
class Foo
{
    public function bar(\Exception $exception)
    {
    }
}
```

I think the problem was that `prec.right` was committing too soon.