### PR TITLE
Fix non-optional method modifier in interface

### DIFF
--- a/corpus/classes/interface_optional_method_modifier.phpt
+++ b/corpus/classes/interface_optional_method_modifier.phpt
@@ -1,0 +1,23 @@
+==========
+Method modifier can be left out
+==========
+
+<?php
+
+interface test {
+    function bar();
+}
+
+?>
+
+---
+
+(program
+    (interface_declaration
+        (name)
+        (method_declaration
+            (name)
+            (formal_parameters)
+        )
+    )
+)

--- a/grammar.js
+++ b/grammar.js
@@ -272,7 +272,7 @@ module.exports = grammar({
 
     method_declaration: $ => choice(
       seq(repeat($._method_modifier), $.function_definition),
-      seq(repeat1($._method_modifier), $._function_definition_header, $._semicolon)
+      seq(repeat($._method_modifier), $._function_definition_header, $._semicolon)
     ),
 
     constructor_declaration: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1319,7 +1319,7 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "REPEAT1",
+              "type": "REPEAT",
               "content": {
                 "type": "SYMBOL",
                 "name": "_method_modifier"


### PR DESCRIPTION
Hi,

Current parser parses

```php
<?php

interface test {
	function bar();
}
```

as 

```
(program 
    (interface_declaration 
        (name) 
        (ERROR 
            (name) 
            (formal_parameters)
        )
    )
)
```

Commit 100fa4bee2a4b3d67ee336d31860ae2937c57ed2 introduces `method_declaration` rule with `repeat1` for case when just prototype exists.

I think that is to handle `abstract` method, like

```php
abstract class Foo {
    function bar();
}
```

PHP does not handle this as a parse error, so I assume it's safe to use `repeat` instead of `repeat1` to get 

```
(program
    (interface_declaration
        (name)
        (method_declaration
            (name)
            (formal_parameters)
        )
    )
)
```

for initial interface code example.

Can `repeat` now be factored out?
