### PR TITLE
Update the build.rs to compile the scanner, and fix a doc-test in the…

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -15,6 +15,7 @@ tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", 
 
 To you the parser, you need to obtain an instance of a [`tree_sitter::Language`][Language] struct for php.
 The `language()` function provides this.
+Passing this struct to a [`tree_sitter::Parser`][Parser] will enable it to parse PHP.
 
 ``` rust
 use tree_sitter::Parser;

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,47 @@
+# tree-sitter-php
+
+This crate provides support of the PHP language for the [tree-sitter][] parsing library. To use this crate, add it to
+the `[dependencies]` section of your
+`Cargo.toml` file. As this crate is not (yet) published to the central registry, you will have to specify it as a git
+dependency, currently we suggest using the `master` branch.
+
+You will also need the [tree-sitter crate][] to do the actual parsing here.
+
+``` toml
+[dependencies]
+tree-sitter = "0.19"
+tree-sitter-php = { git = "https://github.com/tree-sitter/tree-sitter-php.git", branch = "master }
+```
+
+To you the parser, you need to obtain an instance of a [`tree_sitter::Language`][Language] struct for php.
+The `language()` function provides this.
+
+``` rust
+use tree_sitter::Parser;
+
+fn main() {
+    let code = r#"
+    function double(int $x) {
+        return $x * 2;
+    }
+"#;
+    let mut parser = Parser::new();
+    parser
+        .set_language(tree_sitter_php::language())
+        .expect("Error loading PHP parsing support");
+    let parsed = parser.parse(code, None);
+    println!("{:#?}", parsed);
+}
+```
+
+If you have any questions, please reach out to us in the [tree-sitter discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+
+[tree-sitter]: https://tree-sitter.github.io/
+
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -10,22 +10,12 @@ fn main() {
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
-
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
     c_config.compile("parser");
 
     // If your language uses an external scanner written in C++,
     // then include this block of code:
 
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +26,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
     cpp_config.compile("scanner");
-    */
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_javascript::language()).expect("Error loading php grammar");
+//! parser.set_language(tree_sitter_php::language()).expect("Error loading php grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!


### PR DESCRIPTION
Update the build.rs to compile the scanner, and fix a doc-test in the lib.rs.
This makes building it as a rust library possible.

Checklist:
- [x] All tests pass in CI  (They do not touch the rust stuff, so they should...)
- [x] There are sufficient tests for the new fix/feature (I guess we could add more?)
- [x] Grammar rules have not been renamed unless absolutely necessary
- [x] The conflicts section hasn't grown too much
- [x] The parser size hasn't grown too much
