### PR TITLE
Use bindings/node as main in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-try {
-  module.exports = require("./build/Release/tree_sitter_php_binding");
-} catch (error) {
-  try {
-    module.exports = require("./build/Debug/tree_sitter_php_binding");
-  } catch (_) {
-    throw error
-  }
-}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tree-sitter-php",
   "version": "0.19.0",
   "description": "PHP grammar for tree-sitter",
-  "main": "index.js",
+  "main": "bindings/node",
   "keywords": [
     "parser",
     "php"


### PR DESCRIPTION
Hi. 
First of all, thanks for a great tool!

As for the issue this PR fixes: `tree-sitter-php` doesn't export `nodeTypeInfo` as it uses root `index.js` as `main` in `package.json` instead of using `bindings/node` similar to what `tree-sitter-python` [does](https://github.com/tree-sitter/tree-sitter-python/blob/master/package.json).


Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (x new conflicts)
- [x] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
