### PR TITLE
Allows trailing comma and skipping arguments in array destructing and enables heredoc as function argument

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -254,11 +254,11 @@ module.exports = grammar({
 
     enum_declaration_list: $ => seq(
       '{',
-      repeat($._enum_member_declartaion),
+      repeat($._enum_member_declaration),
       '}',
     ),
 
-    _enum_member_declartaion: $ => choice(
+    _enum_member_declaration: $ => choice(
       $.enum_case,
       $.method_declaration,
       $.use_declaration,
@@ -268,7 +268,7 @@ module.exports = grammar({
       optional(field('attributes', $.attribute_list)),
       'case',
       field('name', $.name),
-      optional(field('value', seq('=', choice($.string, $.integer)))),
+      optional(seq('=', field('value', choice($.string, $.integer)))),
       $._semicolon
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -58,6 +58,10 @@ module.exports = grammar({
     [$.union_type, $._return_type],
     [$.if_statement],
 
+    // Needed to support both trailing comma and optional arguments: list($a, $b,) and list( , , $a), same applies for the [] version
+    [$._list_destructing],
+    [$._array_destructing],
+
     [$.namespace_name],
 
     [$.namespace_name_as_prefix],
@@ -1010,19 +1014,21 @@ module.exports = grammar({
     _list_destructing: $ => seq(
       'list',
       '(',
-      commaSep(optional(choice(
+      commaSep1(optional(choice(
         choice(alias($._list_destructing, $.list_literal), $._variable),
         seq($._expression, '=>', choice(alias($._list_destructing, $.list_literal), $._variable))
       ))),
+      optional(','),
       ')'
     ),
 
     _array_destructing: $ => seq(
       '[',
-      commaSep(choice(
+      commaSep1(optional(choice(
         choice(alias($._array_destructing, $.list_literal), $._variable),
         seq($._expression, '=>', choice(alias($._array_destructing, $.list_literal), $._variable))
-      )),
+      ))),
+      optional(','),
       ']'
     ),
 
@@ -1073,6 +1079,7 @@ module.exports = grammar({
     arguments: $ => seq(
       '(',
       commaSep($.argument),
+      optional(','),
       ')'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -58,10 +58,6 @@ module.exports = grammar({
     [$.union_type, $._return_type],
     [$.if_statement],
 
-    // Needed to support both trailing comma and optional arguments: list($a, $b,) and list( , , $a), same applies for the [] version
-    [$._list_destructing],
-    [$._array_destructing],
-
     [$.namespace_name],
 
     [$.namespace_name_as_prefix],
@@ -1018,7 +1014,6 @@ module.exports = grammar({
         choice(alias($._list_destructing, $.list_literal), $._variable),
         seq($._expression, '=>', choice(alias($._list_destructing, $.list_literal), $._variable))
       ))),
-      optional(','),
       ')'
     ),
 
@@ -1028,7 +1023,6 @@ module.exports = grammar({
         choice(alias($._array_destructing, $.list_literal), $._variable),
         seq($._expression, '=>', choice(alias($._array_destructing, $.list_literal), $._variable))
       ))),
-      optional(','),
       ']'
     ),
 

--- a/script/parse-examples.js
+++ b/script/parse-examples.js
@@ -7,9 +7,11 @@ const shell = require('shelljs')
 function main() {
   checkoutExampleProjects([
     { dir: 'laravel', repository: 'https://github.com/laravel/laravel', sha: '9d0862b3340c8243ee072afc181e315ffa35e110' },
+    { dir: 'framework', repository: 'https://github.com/laravel/framework', sha: '45d439e98a6b14afde8911f7d22a265948adbf72' },
     { dir: 'phabricator', repository: 'https://github.com/phacility/phabricator', sha: 'd0b01a41f2498fb2a6487c2d6704dc7acfd4675f' },
     { dir: 'phpunit', repository: 'https://github.com/sebastianbergmann/phpunit', sha: '5e523bdc7dd4d90fed9fb29d1df05347b3e7eaba' },
     { dir: 'WordPress', repository: 'https://github.com/WordPress/WordPress', sha: '45286c5bb3f6fe5005567903ec858d87077eae2c' },
+    { dir: 'mediawiki', repository: 'https://github.com/wikimedia/mediawiki', sha: 'b6b88cbf98fb0c7891324709a85eabc290ed28b4' },
   ])
 
   parseExamples()

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5375,10 +5375,10 @@
           "value": "("
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
                   "type": "CHOICE",
@@ -5386,6 +5386,32 @@
                     {
                       "type": "CHOICE",
                       "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_list_destructing"
+                          },
+                          "named": true,
+                          "value": "list_literal"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_variable"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expression"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "=>"
+                        },
                         {
                           "type": "CHOICE",
                           "members": [
@@ -5403,60 +5429,60 @@
                               "name": "_variable"
                             }
                           ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "_expression"
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "=>"
-                            },
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "ALIAS",
-                                  "content": {
-                                    "type": "SYMBOL",
-                                    "name": "_list_destructing"
-                                  },
-                                  "named": true,
-                                  "value": "list_literal"
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "_variable"
-                                }
-                              ]
-                            }
-                          ]
                         }
                       ]
-                    },
-                    {
-                      "type": "BLANK"
                     }
                   ]
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
                     "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
                       {
                         "type": "CHOICE",
                         "members": [
                           {
                             "type": "CHOICE",
                             "members": [
+                              {
+                                "type": "ALIAS",
+                                "content": {
+                                  "type": "SYMBOL",
+                                  "name": "_list_destructing"
+                                },
+                                "named": true,
+                                "value": "list_literal"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "_variable"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "_expression"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "=>"
+                              },
                               {
                                 "type": "CHOICE",
                                 "members": [
@@ -5474,49 +5500,27 @@
                                     "name": "_variable"
                                   }
                                 ]
-                              },
-                              {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "_expression"
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "=>"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "ALIAS",
-                                        "content": {
-                                          "type": "SYMBOL",
-                                          "name": "_list_destructing"
-                                        },
-                                        "named": true,
-                                        "value": "list_literal"
-                                      },
-                                      {
-                                        "type": "SYMBOL",
-                                        "name": "_variable"
-                                      }
-                                    ]
-                                  }
-                                ]
                               }
                             ]
-                          },
-                          {
-                            "type": "BLANK"
                           }
                         ]
+                      },
+                      {
+                        "type": "BLANK"
                       }
                     ]
                   }
-                }
-              ]
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
             },
             {
               "type": "BLANK"
@@ -5537,10 +5541,10 @@
           "value": "["
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
                   "type": "CHOICE",
@@ -5597,14 +5601,22 @@
                   ]
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
                     "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
                       {
                         "type": "CHOICE",
                         "members": [
@@ -5658,11 +5670,23 @@
                             ]
                           }
                         ]
+                      },
+                      {
+                        "type": "BLANK"
                       }
                     ]
                   }
-                }
-              ]
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
             },
             {
               "type": "BLANK"
@@ -5895,6 +5919,18 @@
                   }
                 }
               ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
             },
             {
               "type": "BLANK"
@@ -7908,6 +7944,12 @@
     ],
     [
       "if_statement"
+    ],
+    [
+      "_list_destructing"
+    ],
+    [
+      "_array_destructing"
     ],
     [
       "namespace_name"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5516,18 +5516,6 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "STRING",
           "value": ")"
         }
@@ -5678,18 +5666,6 @@
                   }
                 ]
               }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
             }
           ]
         },
@@ -7944,12 +7920,6 @@
     ],
     [
       "if_statement"
-    ],
-    [
-      "_list_destructing"
-    ],
-    [
-      "_array_destructing"
     ],
     [
       "namespace_name"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1043,7 +1043,7 @@
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
-            "name": "_enum_member_declartaion"
+            "name": "_enum_member_declaration"
           }
         },
         {
@@ -1052,7 +1052,7 @@
         }
       ]
     },
-    "_enum_member_declartaion": {
+    "_enum_member_declaration": {
       "type": "CHOICE",
       "members": [
         {
@@ -1104,16 +1104,16 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "value",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "="
-                  },
-                  {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
                     "type": "CHOICE",
                     "members": [
                       {
@@ -1126,8 +1126,8 @@
                       }
                     ]
                   }
-                ]
-              }
+                }
+              ]
             },
             {
               "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1625,13 +1625,9 @@
         ]
       },
       "value": {
-        "multiple": true,
+        "multiple": false,
         "required": false,
         "types": [
-          {
-            "type": "=",
-            "named": false
-          },
           {
             "type": "integer",
             "named": true

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -146,7 +146,8 @@ struct Scanner {
 
     for (;;) {
       if (position_in_word == heredoc.word.size()) {
-        if (lexer->lookahead == ';' || lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+        // , and ) is needed to support heredoc in function arguments
+        if (lexer->lookahead == ';' || lexer->lookahead == ',' || lexer->lookahead == ')' || lexer->lookahead == '\n' || lexer->lookahead == '\r') {
           open_heredocs.erase(open_heredocs.begin());
           return End;
         }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -146,6 +146,12 @@ struct Scanner {
 
     for (;;) {
       if (position_in_word == heredoc.word.size()) {
+        // While PHP requires the heredoc end tag to be the very first on a new line, there may be an
+        // arbitrary amount of whitespace before the closing token
+        while (lexer->lookahead == ' ') {
+          advance(lexer);
+        }
+
         // , and ) is needed to support heredoc in function arguments
         if (lexer->lookahead == ';' || lexer->lookahead == ',' || lexer->lookahead == ')' || lexer->lookahead == '\n' || lexer->lookahead == '\r') {
           open_heredocs.erase(open_heredocs.begin());

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -153,8 +153,20 @@ $data = [
 // list() style
 list($id1, $name1) = $data[0];
 
+// Support trailing commma
+list($id1, $name1,) = $data[0];
+
+// Support skipping arguments
+list(, $name1) = $data[0];
+
 // [] style
 [$id1, $name1] = $data[0];
+
+// Support trailing commma
+[$id1, $name1,] = $data[0];
+
+// Support skipping arguments
+[, $name1] = $data[0];
 
 [$error, $canonicalized] = Json::canonicalize($actual);
 
@@ -207,6 +219,56 @@ list($id1, $name1) = $data[0];
       )
     )
   )
+  (comment)
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (variable_name (name))
+      )
+      (subscript_expression
+        (variable_name (name))
+        (integer)
+      )
+    )
+  )
+  (comment)
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (variable_name (name))
+        (variable_name (name))
+      )
+      (subscript_expression
+        (variable_name (name))
+        (integer)
+      )
+    )
+  )
+  (comment)
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (variable_name (name))
+        (variable_name (name))
+      )
+      (subscript_expression
+        (variable_name (name))
+        (integer)
+      )
+    )
+  )
+  (comment)
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (variable_name (name))
+      )
+      (subscript_expression
+        (variable_name (name))
+        (integer)
+      )
+    )
+  )
   (expression_statement
     (assignment_expression
       (list_literal
@@ -216,7 +278,11 @@ list($id1, $name1) = $data[0];
       (scoped_call_expression
         (name)
         (name)
-        (arguments (argument (variable_name (name))))
+        (arguments
+          (argument
+            (variable_name (name))
+          )
+        )
       )
     )
   )

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -144,7 +144,7 @@ HERE);
 
 read(<<<  HERE
 foo #{bar}
-HERE, true);
+HERE , true);
 
 ---
 (program

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -137,6 +137,15 @@ HERE;
 foo #{bar}
 HERE;
 
+// Allow Heredoc as function argument
+read(<<<  HERE
+foo #{bar}
+HERE);
+
+read(<<<  HERE
+foo #{bar}
+HERE, true);
+
 ---
 (program
   (php_tag)
@@ -145,7 +154,24 @@ HERE;
   (text_interpolation (php_tag))
   (expression_statement (heredoc))
   (expression_statement (heredoc))
-  (expression_statement (heredoc)))
+  (expression_statement (heredoc))
+  (comment)
+  (expression_statement
+    (function_call_expression
+      (name)
+      (arguments (argument (heredoc)))
+    )
+  )
+  (expression_statement
+    (function_call_expression
+      (name)
+      (arguments
+        (argument (heredoc))
+        (argument (boolean))
+      )
+    )
+  )
+)
 
 ==========================
 Nowdocs


### PR DESCRIPTION
After adding a few more test projects, a few more edge cases of the grammar was identified. This PR adds those test projects, fixes any surfaced errors and adds tree-sitter tests for them explicitly.

### Changes

- Added test projects: Laravel Framework, MediaWiki
- Array destructuring changes:
  - Added support for trailing comma
  - Added support for skipping arguments
  - Require at least one argument
- Added support for using Heredoc as function argument

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature (new tests added for edge cases)
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2552, PR: 2579)
