### PR TITLE
Fixes #92: Error on exponentiation with expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -18,14 +18,15 @@ const PREC = {
   SHIFT: 15,
   PLUS: 16,
   TIMES: 17,
-  NEG: 18,
-  INSTANCEOF: 19,
-  INC: 20,
-  SCOPE: 21,
-  NEW: 22,
-  CALL: 23,
-  MEMBER: 24,
-  DEREF: 25
+  EXPONENTIAL: 18,
+  NEG: 19,
+  INSTANCEOF: 20,
+  INC: 21,
+  SCOPE: 22,
+  NEW: 23,
+  CALL: 24,
+  MEMBER: 25,
+  DEREF: 26
 };
 
 module.exports = grammar({
@@ -835,10 +836,10 @@ module.exports = grammar({
       prec.left(PREC.NEG, seq(choice('+', '-', '~', '!'), $._expression))
     ),
 
-    exponentiation_expression: $ => prec.right(PREC.TIMES, seq(
+    exponentiation_expression: $ => prec.right(PREC.EXPONENTIAL, seq(
       choice($.clone_expression, $._primary_expression),
       '**',
-      choice($.exponentiation_expression, $.clone_expression, $._primary_expression)
+      choice($.exponentiation_expression, $.clone_expression, $.unary_op_expression, $._primary_expression)
     )),
 
     clone_expression: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4284,7 +4284,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": 18,
+          "value": 19,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4320,7 +4320,7 @@
     },
     "exponentiation_expression": {
       "type": "PREC_RIGHT",
-      "value": 17,
+      "value": 18,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4351,6 +4351,10 @@
               {
                 "type": "SYMBOL",
                 "name": "clone_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "unary_op_expression"
               },
               {
                 "type": "SYMBOL",
@@ -4678,7 +4682,7 @@
     },
     "object_creation_expression": {
       "type": "PREC_RIGHT",
-      "value": 22,
+      "value": 23,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -4812,7 +4816,7 @@
     },
     "update_expression": {
       "type": "PREC_LEFT",
-      "value": 20,
+      "value": 21,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -5273,7 +5277,7 @@
     },
     "member_access_expression": {
       "type": "PREC",
-      "value": 24,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5298,7 +5302,7 @@
     },
     "nullsafe_member_access_expression": {
       "type": "PREC",
-      "value": 24,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5323,7 +5327,7 @@
     },
     "scoped_property_access_expression": {
       "type": "PREC",
-      "value": 24,
+      "value": 25,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5706,7 +5710,7 @@
     },
     "function_call_expression": {
       "type": "PREC",
-      "value": 23,
+      "value": 24,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5774,7 +5778,7 @@
     },
     "scoped_call_expression": {
       "type": "PREC",
-      "value": 23,
+      "value": 24,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5837,7 +5841,7 @@
     },
     "relative_scope": {
       "type": "PREC",
-      "value": 21,
+      "value": 22,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -5964,7 +5968,7 @@
     },
     "member_call_expression": {
       "type": "PREC",
-      "value": 23,
+      "value": 24,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5997,7 +6001,7 @@
     },
     "nullsafe_member_call_expression": {
       "type": "PREC",
-      "value": 23,
+      "value": 24,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6151,7 +6155,7 @@
     },
     "_dereferencable_expression": {
       "type": "PREC",
-      "value": 25,
+      "value": 26,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -6769,7 +6773,7 @@
       "members": [
         {
           "type": "PREC",
-          "value": 19,
+          "value": 20,
           "content": {
             "type": "SEQ",
             "members": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1732,6 +1732,10 @@
         {
           "type": "exponentiation_expression",
           "named": true
+        },
+        {
+          "type": "unary_op_expression",
+          "named": true
         }
       ]
     }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -19,14 +19,30 @@ Exponentiation
 
 <?php
 $foo = 2 ** 2;
+$a = 3;
+echo $a ** -$a;
 
 ---
 
 (program
   (php_tag)
   (expression_statement (assignment_expression
-    (variable_name (name))
-    (exponentiation_expression (integer) (integer)))))
+    left: (variable_name (name))
+    right: (exponentiation_expression (integer) (integer)))
+  )
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (integer)))
+  (echo_statement
+    (exponentiation_expression
+      (variable_name (name))
+      (unary_op_expression
+        (variable_name (name))
+      )
+    )
+  )
+)
 
 ==========================
 Reserved Identifiers as Names


### PR DESCRIPTION
Fixes #92 by adding possibility of exponential op containing an unary op.

Also fixes precedence issue kindly pointed out by @Sjord 

Checklist:
- [ ] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2579, PR: 2579)
