### PR TITLE
Fixes #96:Parse error on exponentiation with augmented assignment

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -837,9 +837,9 @@ module.exports = grammar({
     ),
 
     exponentiation_expression: $ => prec.right(PREC.EXPONENTIAL, seq(
-      choice($.clone_expression, $._primary_expression),
+      field('left', choice($.clone_expression, $._primary_expression, $.unary_op_expression, $.match_expression)),
       '**',
-      choice($.exponentiation_expression, $.clone_expression, $.unary_op_expression, $._primary_expression)
+      field('right', choice($.exponentiation_expression, $.clone_expression, $.unary_op_expression, $._primary_expression, $.augmented_assignment_expression, $.match_expression, $.cast_expression))
     )),
 
     clone_expression: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4325,42 +4325,70 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "clone_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_primary_expression"
-              }
-            ]
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "clone_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_primary_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "unary_op_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "match_expression"
+                }
+              ]
+            }
           },
           {
             "type": "STRING",
             "value": "**"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "exponentiation_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "clone_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "unary_op_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_primary_expression"
-              }
-            ]
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "exponentiation_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "clone_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "unary_op_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_primary_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "augmented_assignment_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "match_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "cast_expression"
+                }
+              ]
+            }
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1716,28 +1716,59 @@
   {
     "type": "exponentiation_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_primary_expression",
-          "named": true
-        },
-        {
-          "type": "clone_expression",
-          "named": true
-        },
-        {
-          "type": "exponentiation_expression",
-          "named": true
-        },
-        {
-          "type": "unary_op_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_primary_expression",
+            "named": true
+          },
+          {
+            "type": "clone_expression",
+            "named": true
+          },
+          {
+            "type": "match_expression",
+            "named": true
+          },
+          {
+            "type": "unary_op_expression",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_primary_expression",
+            "named": true
+          },
+          {
+            "type": "augmented_assignment_expression",
+            "named": true
+          },
+          {
+            "type": "clone_expression",
+            "named": true
+          },
+          {
+            "type": "exponentiation_expression",
+            "named": true
+          },
+          {
+            "type": "match_expression",
+            "named": true
+          },
+          {
+            "type": "unary_op_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -21,14 +21,20 @@ Exponentiation
 $foo = 2 ** 2;
 $a = 3;
 echo $a ** -$a;
+$a ** $c += $b;
 
 ---
 
 (program
   (php_tag)
-  (expression_statement (assignment_expression
-    left: (variable_name (name))
-    right: (exponentiation_expression (integer) (integer)))
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (exponentiation_expression
+        left: (integer)
+        right: (integer)
+      )
+    )
   )
   (expression_statement
     (assignment_expression
@@ -36,9 +42,18 @@ echo $a ** -$a;
       right: (integer)))
   (echo_statement
     (exponentiation_expression
-      (variable_name (name))
-      (unary_op_expression
+      left: (variable_name (name))
+      right: (unary_op_expression
         (variable_name (name))
+      )
+    )
+  )
+  (expression_statement
+    (exponentiation_expression
+      left: (variable_name (name))
+      right: (augmented_assignment_expression
+        left: (variable_name (name))
+        right: (variable_name (name))
       )
     )
   )
@@ -104,7 +119,7 @@ Cast expressions in assignments
 
 <?php
 
-(int) $foo = (integer)$bar;
+(int) $foo = (integer) $bar;
 (int) $foo += 5;
 
 ---


### PR DESCRIPTION
After examining this case further, I've also added support for match expressions, and cast_expressions (only right-hand side)

Checklist:
- [ ] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2579, PR: 2595)
