### PR TITLE
Adds support for references

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -229,6 +229,10 @@
         "value": ";"
       }
     },
+    "reference_modifier": {
+      "type": "STRING",
+      "value": "&"
+    },
     "function_static_declaration": {
       "type": "SEQ",
       "members": [
@@ -2004,8 +2008,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "&"
+              "type": "FIELD",
+              "name": "reference_modifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "reference_modifier"
+              }
             },
             {
               "type": "BLANK"
@@ -2084,8 +2092,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "&"
+              "type": "FIELD",
+              "name": "reference_modifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "reference_modifier"
+              }
             },
             {
               "type": "BLANK"
@@ -2311,8 +2323,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "&"
+              "type": "FIELD",
+              "name": "reference_modifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "reference_modifier"
+              }
             },
             {
               "type": "BLANK"
@@ -2393,8 +2409,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "&"
+              "type": "FIELD",
+              "name": "reference_modifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "reference_modifier"
+              }
             },
             {
               "type": "BLANK"
@@ -2562,7 +2582,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[aA][rR][rR][aA][yY]"
+          },
+          "named": false,
           "value": "array"
         },
         {
@@ -2606,7 +2631,12 @@
           "value": "string"
         },
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[uU][nN][sS][eE][tT]"
+          },
+          "named": false,
           "value": "unset"
         }
       ]
@@ -2847,7 +2877,7 @@
     },
     "float": {
       "type": "PATTERN",
-      "value": "\\d*(_\\d+)*((\\.\\d*(_\\d+)*)?([eE][\\+-]?\\d+(_\\d+)*)|(\\.\\d\\d*(_\\d+)*)([eE][\\+-]?\\d+(_\\d+)*)?)"
+      "value": "\\d*(_\\d+)*((\\.\\d*(_\\d+)*)?([eE][\\+-]?\\d+(_\\d+)*)|(\\.\\d*(_\\d+)*)([eE][\\+-]?\\d+(_\\d+)*)?)"
     },
     "try_statement": {
       "type": "SEQ",
@@ -3514,25 +3544,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "&"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "by_ref"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         },
         {
           "type": "SYMBOL",
@@ -4213,6 +4230,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "reference_assignment_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "yield_expression"
         },
         {
@@ -4569,8 +4590,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "&"
+              "type": "FIELD",
+              "name": "reference_modifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "reference_modifier"
+              }
             },
             {
               "type": "BLANK"
@@ -4639,19 +4664,16 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "&"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "variable_reference"
+                  },
+                  "named": true,
+                  "value": "by_ref"
                 },
                 {
                   "type": "SYMBOL",
@@ -4669,19 +4691,16 @@
                     "value": ","
                   },
                   {
-                    "type": "SEQ",
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "&"
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "variable_reference"
+                        },
+                        "named": true,
+                        "value": "by_ref"
                       },
                       {
                         "type": "SYMBOL",
@@ -5120,16 +5139,46 @@
             "value": "="
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "&"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          }
+        ]
+      }
+    },
+    "reference_assignment_expression": {
+      "type": "PREC_RIGHT",
+      "value": 4,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "list_literal"
+                }
+              ]
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          },
+          {
+            "type": "STRING",
+            "value": "&"
           },
           {
             "type": "FIELD",
@@ -5434,6 +5483,10 @@
                         {
                           "type": "SYMBOL",
                           "name": "_variable"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "by_ref"
                         }
                       ]
                     },
@@ -5463,6 +5516,10 @@
                             {
                               "type": "SYMBOL",
                               "name": "_variable"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "by_ref"
                             }
                           ]
                         }
@@ -5505,6 +5562,10 @@
                               {
                                 "type": "SYMBOL",
                                 "name": "_variable"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "by_ref"
                               }
                             ]
                           },
@@ -5534,6 +5595,10 @@
                                   {
                                     "type": "SYMBOL",
                                     "name": "_variable"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "by_ref"
                                   }
                                 ]
                               }
@@ -5571,58 +5636,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "_array_destructing"
-                          },
-                          "named": true,
-                          "value": "list_literal"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_variable"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_expression"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "=>"
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "ALIAS",
-                              "content": {
-                                "type": "SYMBOL",
-                                "name": "_array_destructing"
-                              },
-                              "named": true,
-                              "value": "list_literal"
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "_variable"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_array_destructing_element"
                 },
                 {
                   "type": "BLANK"
@@ -5642,58 +5657,8 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "ALIAS",
-                                "content": {
-                                  "type": "SYMBOL",
-                                  "name": "_array_destructing"
-                                },
-                                "named": true,
-                                "value": "list_literal"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "_variable"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "_expression"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "=>"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "ALIAS",
-                                    "content": {
-                                      "type": "SYMBOL",
-                                      "name": "_array_destructing"
-                                    },
-                                    "named": true,
-                                    "value": "list_literal"
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "_variable"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "type": "SYMBOL",
+                        "name": "_array_destructing_element"
                       },
                       {
                         "type": "BLANK"
@@ -5708,6 +5673,68 @@
         {
           "type": "STRING",
           "value": "]"
+        }
+      ]
+    },
+    "_array_destructing_element": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_array_destructing"
+              },
+              "named": true,
+              "value": "list_literal"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_variable"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "by_ref"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_array_destructing"
+                  },
+                  "named": true,
+                  "value": "list_literal"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "by_ref"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -5977,6 +6004,22 @@
                   "value": ":"
                 }
               ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "reference_modifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "reference_modifier"
+              }
             },
             {
               "type": "BLANK"
@@ -6855,6 +6898,32 @@
         }
       ]
     },
+    "variable_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "variable_name"
+        }
+      ]
+    },
+    "by_ref": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_callable_variable"
+        }
+      ]
+    },
     "yield_expression": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -6905,19 +6974,11 @@
         "type": "CHOICE",
         "members": [
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "&"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "by_ref"
               },
               {
                 "type": "SYMBOL",
@@ -6940,17 +7001,14 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "&"
+                    "type": "SYMBOL",
+                    "name": "by_ref"
                   },
                   {
-                    "type": "BLANK"
+                    "type": "SYMBOL",
+                    "name": "_expression"
                   }
                 ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
               }
             ]
           },
@@ -8104,12 +8162,16 @@
       "_reserved_identifier"
     ],
     [
-      "_primary_expression",
-      "_array_destructing"
-    ],
-    [
       "_array_destructing",
       "array_creation_expression"
+    ],
+    [
+      "_array_destructing_element",
+      "array_element_initializer"
+    ],
+    [
+      "_primary_expression",
+      "_array_destructing_element"
     ],
     [
       "union_type",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -48,6 +48,10 @@
         "named": true
       },
       {
+        "type": "reference_assignment_expression",
+        "named": true
+      },
+      {
         "type": "require_expression",
         "named": true
       },
@@ -358,6 +362,16 @@
           }
         ]
       },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
+            "named": true
+          }
+        ]
+      },
       "return_type": {
         "multiple": false,
         "required": false,
@@ -389,6 +403,10 @@
       "required": true,
       "types": [
         {
+          "type": "by_ref",
+          "named": true
+        },
+        {
           "type": "variable_name",
           "named": true
         }
@@ -405,6 +423,16 @@
         "types": [
           {
             "type": "name",
+            "named": true
+          }
+        ]
+      },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
             "named": true
           }
         ]
@@ -468,6 +496,10 @@
           "named": true
         },
         {
+          "type": "by_ref",
+          "named": true
+        },
+        {
           "type": "variadic_unpacking",
           "named": true
         }
@@ -494,6 +526,16 @@
         "types": [
           {
             "type": "formal_parameters",
+            "named": true
+          }
+        ]
+      },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
             "named": true
           }
         ]
@@ -970,6 +1012,45 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "by_ref",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "dynamic_variable_name",
+          "named": true
+        },
+        {
+          "type": "function_call_expression",
+          "named": true
+        },
+        {
+          "type": "member_call_expression",
+          "named": true
+        },
+        {
+          "type": "nullsafe_member_call_expression",
+          "named": true
+        },
+        {
+          "type": "scoped_call_expression",
+          "named": true
+        },
+        {
+          "type": "subscript_expression",
+          "named": true
+        },
+        {
+          "type": "variable_name",
           "named": true
         }
       ]
@@ -1909,6 +1990,10 @@
           "named": true
         },
         {
+          "type": "by_ref",
+          "named": true
+        },
+        {
           "type": "list_literal",
           "named": true
         },
@@ -2060,6 +2145,16 @@
         "types": [
           {
             "type": "formal_parameters",
+            "named": true
+          }
+        ]
+      },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
             "named": true
           }
         ]
@@ -2245,6 +2340,10 @@
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "by_ref",
           "named": true
         },
         {
@@ -2666,6 +2765,16 @@
         "types": [
           {
             "type": "formal_parameters",
+            "named": true
+          }
+        ]
+      },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
             "named": true
           }
         ]
@@ -3219,6 +3328,10 @@
           "named": true
         },
         {
+          "type": "by_ref",
+          "named": true
+        },
+        {
           "type": "list_literal",
           "named": true
         }
@@ -3437,6 +3550,81 @@
         }
       ]
     }
+  },
+  {
+    "type": "reference_assignment_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "cast_expression",
+            "named": true
+          },
+          {
+            "type": "dynamic_variable_name",
+            "named": true
+          },
+          {
+            "type": "function_call_expression",
+            "named": true
+          },
+          {
+            "type": "list_literal",
+            "named": true
+          },
+          {
+            "type": "member_access_expression",
+            "named": true
+          },
+          {
+            "type": "member_call_expression",
+            "named": true
+          },
+          {
+            "type": "nullsafe_member_access_expression",
+            "named": true
+          },
+          {
+            "type": "nullsafe_member_call_expression",
+            "named": true
+          },
+          {
+            "type": "scoped_call_expression",
+            "named": true
+          },
+          {
+            "type": "scoped_property_access_expression",
+            "named": true
+          },
+          {
+            "type": "subscript_expression",
+            "named": true
+          },
+          {
+            "type": "variable_name",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "reference_modifier",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "relative_scope",
@@ -3767,6 +3955,16 @@
         "types": [
           {
             "type": "variable_name",
+            "named": true
+          }
+        ]
+      },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
             "named": true
           }
         ]
@@ -4320,6 +4518,16 @@
           }
         ]
       },
+      "reference_modifier": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "reference_modifier",
+            "named": true
+          }
+        ]
+      },
       "type": {
         "multiple": false,
         "required": false,
@@ -4783,11 +4991,11 @@
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "fn",
@@ -4887,11 +5095,11 @@
   },
   {
     "type": "null",
-    "named": true
+    "named": false
   },
   {
     "type": "null",
-    "named": false
+    "named": true
   },
   {
     "type": "object",
@@ -4959,11 +5167,11 @@
   },
   {
     "type": "string",
-    "named": false
+    "named": true
   },
   {
     "type": "string",
-    "named": true
+    "named": false
   },
   {
     "type": "switch",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -140,7 +140,7 @@ class foo {
 				(simple_parameter
 					name: (variable_name (name))))
 	    body: (compound_statement
-				(expression_statement (assignment_expression
+				(expression_statement (reference_assignment_expression
 	        left: (subscript_expression (variable_name (name)) (string))
 	        right: (variable_name (name))))
 				(expression_statement (assignment_expression

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -696,7 +696,7 @@ ob_start(function($buffer) use (&$storage,) { $storage .= $buffer; }, 20);
         (argument
           (anonymous_function_creation_expression
             parameters: (formal_parameters (simple_parameter name: (variable_name (name))))
-            (anonymous_function_use_clause (variable_name (name)))
+            (anonymous_function_use_clause (by_ref (variable_name (name))))
             body: (compound_statement (expression_statement (augmented_assignment_expression
               left: (variable_name (name))
               right: (variable_name (name)))))))
@@ -708,7 +708,7 @@ ob_start(function($buffer) use (&$storage,) { $storage .= $buffer; }, 20);
         (argument
           (anonymous_function_creation_expression
             parameters: (formal_parameters (simple_parameter name: (variable_name (name))))
-            (anonymous_function_use_clause (variable_name (name)))
+            (anonymous_function_use_clause (by_ref (variable_name (name))))
             body: (compound_statement (expression_statement (augmented_assignment_expression
               left: (variable_name (name))
               right: (variable_name (name)))))))
@@ -1072,6 +1072,7 @@ $fn1 = fn($x) => $x + $y;
       (static_modifier)
       parameters: (formal_parameters
         (simple_parameter
+          reference_modifier: (reference_modifier)
           name: (variable_name (name))
         )
       )
@@ -1080,6 +1081,7 @@ $fn1 = fn($x) => $x + $y;
   )
   (expression_statement
     (arrow_function
+      reference_modifier: (reference_modifier)
       parameters: (formal_parameters
         (simple_parameter
           name: (variable_name (name))
@@ -1162,3 +1164,246 @@ $a . $c << $b ;
             (name))
           (variable_name
             (name))))))
+
+
+====================================
+References
+====================================
+
+<?php
+
+$a =& new B;
+$a = &$x;
+
+function test($a, &... $b) {}
+function test($a, Type &... $b) {}
+
+static fn(&$x) => $x;
+fn&($x) => $x;
+
+function() use($a, &$b) {};
+function &($a) {};
+
+foreach ($a as &$b) {}
+foreach ($a as $b => &$c) {}
+
+f(&$a);
+
+function a(&$b) {}
+function &a($b) {}
+
+$target = &$GLOBALS['_' . \strtoupper($array)];
+
+array('a', &$b, 'c' => 'd', 'e' => &$f);
+
+[&$x];
+
+list(&$v) = $x;
+
+list('k' => &$v) = $x;
+
+[&$v] = $x;
+
+['k' => &$v] = $x;
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (reference_assignment_expression
+      (variable_name (name))
+      (object_creation_expression (name))
+    )
+  )
+  (expression_statement
+    (reference_assignment_expression
+      (variable_name (name))
+      (variable_name (name))
+    )
+  )
+  (function_definition
+    (name)
+    (formal_parameters
+      (simple_parameter
+        (variable_name (name))
+      )
+      (variadic_parameter
+        (reference_modifier)
+        (variable_name (name))
+      )
+    )
+    (compound_statement)
+  )
+  (function_definition
+    (name)
+    (formal_parameters
+      (simple_parameter
+        (variable_name (name))
+      )
+      (variadic_parameter
+        (type_list (named_type (name)))
+        (reference_modifier)
+        (variable_name (name))
+      )
+    )
+    (compound_statement)
+  )
+  (expression_statement
+    (arrow_function
+      (static_modifier)
+      (formal_parameters
+        (simple_parameter
+          (reference_modifier)
+          (variable_name (name))
+        )
+      )
+      (variable_name (name))
+    )
+  )
+  (expression_statement
+    (arrow_function
+      (reference_modifier)
+      (formal_parameters
+        (simple_parameter
+          (variable_name (name))
+        )
+      )
+      (variable_name (name))
+    )
+  )
+  (expression_statement
+    (anonymous_function_creation_expression
+      (formal_parameters)
+      (anonymous_function_use_clause
+        (variable_name (name))
+        (by_ref (variable_name (name)))
+      )
+      (compound_statement)
+    )
+  )
+  (expression_statement
+    (anonymous_function_creation_expression
+      (reference_modifier)
+      (formal_parameters
+        (simple_parameter
+          (variable_name (name))
+        )
+      )
+      (compound_statement)
+    )
+  )
+  (foreach_statement
+    (variable_name (name))
+    (by_ref (variable_name (name)))
+    (compound_statement)
+  )
+  (foreach_statement
+    (variable_name (name))
+    (pair
+      (variable_name (name))
+      (by_ref (variable_name (name)))
+    )
+    (compound_statement)
+  )
+  (expression_statement
+    (function_call_expression
+      (name)
+      (arguments
+        (argument
+          (reference_modifier)
+          (variable_name (name))
+        )
+      )
+    )
+  )
+  (function_definition
+    (name)
+    (formal_parameters
+      (simple_parameter
+        (reference_modifier)
+        (variable_name (name))
+      )
+    )
+    (compound_statement)
+  )
+  (function_definition
+    (reference_modifier)
+    (name)
+    (formal_parameters
+      (simple_parameter
+        (variable_name (name))
+      )
+    )
+    (compound_statement)
+  )
+  (expression_statement
+    (reference_assignment_expression
+      (variable_name (name))
+      (subscript_expression
+        (variable_name (name))
+        (binary_expression
+          (string)
+          (function_call_expression
+            (qualified_name
+              (namespace_name_as_prefix)
+              (name)
+            )
+            (arguments
+              (argument (variable_name (name)))
+            )
+          )
+        )
+      )
+    )
+  )
+  (expression_statement
+    (array_creation_expression
+      (array_element_initializer (string))
+      (array_element_initializer (by_ref (variable_name (name))))
+      (array_element_initializer (string) (string))
+      (array_element_initializer (string) (by_ref (variable_name (name))))
+    )
+  )
+  (expression_statement
+    (array_creation_expression
+      (array_element_initializer (by_ref (variable_name (name))))
+    )
+  )
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (by_ref
+          (variable_name (name))
+        )
+      )
+      (variable_name (name))
+    )
+  )
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (string)
+        (by_ref (variable_name (name)))
+      )
+      (variable_name (name))
+    )
+  )
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (by_ref (variable_name (name)))
+      )
+      (variable_name (name))
+    )
+  )
+  (expression_statement
+    (assignment_expression
+      (list_literal
+        (string)
+        (by_ref (variable_name (name)))
+      )
+      (variable_name (name))
+    )
+  )
+)


### PR DESCRIPTION
Adds support for references by combining two approaches:

1. Where anything included in `_callable_variable` is used directly, we wrap it in `by_ref`
2. Where there is a wrapping container already (or where `by_ref` simply doesn't make sense, like function returns) we apply the `reference_modifier` field

One new conflict has been added to disambiguate array creation and array destructing.

Also: Fixes float without decimal parts (but with trailing .)

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (1 new conflicts)
- [x] The parser size hasn't grown too much (master: 2595, PR: 2624)