### PR TITLE
Bugfixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1264,7 +1264,11 @@ module.exports = grammar({
     variable_reference: $ => seq('&', $.variable_name),
     by_ref: $ => seq(
       '&',
-      $._callable_variable
+      choice(
+        $._callable_variable,
+        $.member_access_expression,
+        $.nullsafe_member_access_expression,
+      )
     ),
 
     yield_expression: $ => prec.right(seq(

--- a/grammar.js
+++ b/grammar.js
@@ -273,7 +273,7 @@ module.exports = grammar({
 
     enum_case: $ => seq(
       optional(field('attributes', $.attribute_list)),
-      'case',
+      keyword('case'),
       field('name', $.name),
       optional(seq('=', field('value', choice($.string, $.integer)))),
       $._semicolon
@@ -490,7 +490,7 @@ module.exports = grammar({
 
     primitive_type: $ => choice(
       'array',
-      'callable', // not legal in property types
+      keyword('callable'), // not legal in property types
       'iterable',
       'bool',
       'float',
@@ -504,18 +504,18 @@ module.exports = grammar({
     ),
 
     cast_type: $ => choice(
-      keyword('array'),
-      'binary',
-      'bool',
-      'boolean',
-      'double',
-      'int',
-      'integer',
-      'float',
-      'object',
-      'real',
-      'string',
-      keyword('unset')
+      keyword('array', false),
+      keyword('binary', false),
+      keyword('bool', false),
+      keyword('boolean', false),
+      keyword('double', false),
+      keyword('int', false),
+      keyword('integer', false),
+      keyword('float', false),
+      keyword('object', false),
+      keyword('real', false),
+      keyword('string', false),
+      keyword('unset', false)
     ),
 
     _return_type: $ => seq(':', field('return_type', $._type)),
@@ -533,7 +533,7 @@ module.exports = grammar({
     ),
 
     declare_statement: $ => seq(
-      'declare', '(', $.declare_directive, ')',
+      keyword('declare'), '(', $.declare_directive, ')',
       choice(
         $._statement,
         seq(':', repeat($._statement), keyword('enddeclare'), $._semicolon),
@@ -851,7 +851,7 @@ module.exports = grammar({
     )),
 
     clone_expression: $ => seq(
-      'clone', $._primary_expression
+      keyword('clone'), $._primary_expression
     ),
 
     _primary_expression: $ => choice(
@@ -881,7 +881,7 @@ module.exports = grammar({
     ),
 
     print_intrinsic: $ => seq(
-      'print', $._expression
+      keyword('print'), $._expression
     ),
 
     anonymous_function_creation_expression: $ => seq(
@@ -904,12 +904,12 @@ module.exports = grammar({
 
     object_creation_expression: $ => prec.right(PREC.NEW, choice(
       seq(
-        'new',
+        keyword('new'),
         $._class_type_designator,
         optional($.arguments)
       ),
       seq(
-        'new',
+        keyword('new'),
         keyword('class'),
         optional($.arguments),
         optional($.base_clause),
@@ -1026,7 +1026,7 @@ module.exports = grammar({
     list_literal: $ => choice($._list_destructing, $._array_destructing),
 
     _list_destructing: $ => seq(
-      'list',
+      keyword('list'),
       '(',
       commaSep1(optional(choice(
         choice(alias($._list_destructing, $.list_literal), $._variable, $.by_ref),
@@ -1152,7 +1152,7 @@ module.exports = grammar({
     )),
 
     array_creation_expression: $ => choice(
-      seq('array', '(', commaSep($.array_element_initializer), optional(','), ')'),
+      seq(keyword('array'), '(', commaSep($.array_element_initializer), optional(','), ')'),
       seq('[', commaSep($.array_element_initializer), optional(','), ']')
     ),
 
@@ -1272,10 +1272,10 @@ module.exports = grammar({
     ),
 
     yield_expression: $ => prec.right(seq(
-      'yield',
+      keyword('yield'),
       optional(choice(
         $.array_element_initializer,
-        seq('from', $._expression)
+        seq(keyword('from'), $._expression)
       ))
     )),
 
@@ -1293,9 +1293,9 @@ module.exports = grammar({
       )),
       prec.right(PREC.NULL_COALESCE, seq($._expression, '??', $._expression)),
       ...[
-        [alias(/and|AND/, 'and'), PREC.LOGICAL_AND_2],
-        [alias(/or|OR/, 'or'), PREC.LOGICAL_OR_2],
-        [alias(/xor|XOR/, 'xor'), PREC.LOGICAL_XOR],
+        [keyword('and'), PREC.LOGICAL_AND_2],
+        [keyword('or'), PREC.LOGICAL_OR_2],
+        [keyword('xor'), PREC.LOGICAL_XOR],
         ['||', PREC.LOGICAL_OR_1],
         ['&&', PREC.LOGICAL_AND_1],
         ['|', PREC.BITWISE_OR],

--- a/grammar.js
+++ b/grammar.js
@@ -942,7 +942,7 @@ module.exports = grammar({
 
     cast_expression: $ => prec(PREC.CAST, seq(
       '(', field('type', $.cast_type), ')',
-      field('value', $._unary_expression)
+      field('value', choice($._unary_expression, $.include_expression, $.include_once_expression))
     )),
 
     cast_variable: $ => prec(PREC.CAST, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6919,8 +6919,21 @@
           "value": "&"
         },
         {
-          "type": "SYMBOL",
-          "name": "_callable_variable"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_callable_variable"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "member_access_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nullsafe_member_access_expression"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1093,7 +1093,12 @@
           ]
         },
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[cC][aA][sS][eE]"
+          },
+          "named": false,
           "value": "case"
         },
         {
@@ -2533,7 +2538,12 @@
           "value": "array"
         },
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[cC][aA][lL][lL][aA][bB][lL][eE]"
+          },
+          "named": false,
           "value": "callable"
         },
         {
@@ -2582,62 +2592,52 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[aA][rR][rR][aA][yY]"
-          },
-          "named": false,
-          "value": "array"
+          "type": "PATTERN",
+          "value": "[aA][rR][rR][aA][yY]"
         },
         {
-          "type": "STRING",
-          "value": "binary"
+          "type": "PATTERN",
+          "value": "[bB][iI][nN][aA][rR][yY]"
         },
         {
-          "type": "STRING",
-          "value": "bool"
+          "type": "PATTERN",
+          "value": "[bB][oO][oO][lL]"
         },
         {
-          "type": "STRING",
-          "value": "boolean"
+          "type": "PATTERN",
+          "value": "[bB][oO][oO][lL][eE][aA][nN]"
         },
         {
-          "type": "STRING",
-          "value": "double"
+          "type": "PATTERN",
+          "value": "[dD][oO][uU][bB][lL][eE]"
         },
         {
-          "type": "STRING",
-          "value": "int"
+          "type": "PATTERN",
+          "value": "[iI][nN][tT]"
         },
         {
-          "type": "STRING",
-          "value": "integer"
+          "type": "PATTERN",
+          "value": "[iI][nN][tT][eE][gG][eE][rR]"
         },
         {
-          "type": "STRING",
-          "value": "float"
+          "type": "PATTERN",
+          "value": "[fF][lL][oO][aA][tT]"
         },
         {
-          "type": "STRING",
-          "value": "object"
+          "type": "PATTERN",
+          "value": "[oO][bB][jJ][eE][cC][tT]"
         },
         {
-          "type": "STRING",
-          "value": "real"
+          "type": "PATTERN",
+          "value": "[rR][eE][aA][lL]"
         },
         {
-          "type": "STRING",
-          "value": "string"
+          "type": "PATTERN",
+          "value": "[sS][tT][rR][iI][nN][gG]"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[uU][nN][sS][eE][tT]"
-          },
-          "named": false,
-          "value": "unset"
+          "type": "PATTERN",
+          "value": "[uU][nN][sS][eE][tT]"
         }
       ]
     },
@@ -2761,7 +2761,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[dD][eE][cC][lL][aA][rR][eE]"
+          },
+          "named": false,
           "value": "declare"
         },
         {
@@ -4422,7 +4427,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[cC][lL][oO][nN][eE]"
+          },
+          "named": false,
           "value": "clone"
         },
         {
@@ -4548,7 +4558,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[pP][rR][iI][nN][tT]"
+          },
+          "named": false,
           "value": "print"
         },
         {
@@ -4741,7 +4756,12 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[nN][eE][wW]"
+                },
+                "named": false,
                 "value": "new"
               },
               {
@@ -4766,7 +4786,12 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[nN][eE][wW]"
+                },
+                "named": false,
                 "value": "new"
               },
               {
@@ -5465,7 +5490,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[lL][iI][sS][tT]"
+          },
+          "named": false,
           "value": "list"
         },
         {
@@ -6294,7 +6324,12 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[aA][rR][rR][aA][yY]"
+              },
+              "named": false,
               "value": "array"
             },
             {
@@ -6957,7 +6992,12 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[yY][iI][eE][lL][dD]"
+            },
+            "named": false,
             "value": "yield"
           },
           {
@@ -6974,7 +7014,12 @@
                     "type": "SEQ",
                     "members": [
                       {
-                        "type": "STRING",
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[fF][rR][oO][mM]"
+                        },
+                        "named": false,
                         "value": "from"
                       },
                       {
@@ -7128,7 +7173,7 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "and|AND"
+                    "value": "[aA][nN][dD]"
                   },
                   "named": false,
                   "value": "and"
@@ -7166,7 +7211,7 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "or|OR"
+                    "value": "[oO][rR]"
                   },
                   "named": false,
                   "value": "or"
@@ -7204,7 +7249,7 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "xor|XOR"
+                    "value": "[xX][oO][rR]"
                   },
                   "named": false,
                   "value": "xor"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5071,8 +5071,21 @@
             "type": "FIELD",
             "name": "value",
             "content": {
-              "type": "SYMBOL",
-              "name": "_unary_expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_unary_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "include_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "include_once_expression"
+                }
+              ]
             }
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1034,7 +1034,15 @@
           "named": true
         },
         {
+          "type": "member_access_expression",
+          "named": true
+        },
+        {
           "type": "member_call_expression",
+          "named": true
+        },
+        {
+          "type": "nullsafe_member_access_expression",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4874,15 +4874,7 @@
     "named": false
   },
   {
-    "type": "binary",
-    "named": false
-  },
-  {
     "type": "bool",
-    "named": false
-  },
-  {
-    "type": "boolean",
     "named": false
   },
   {
@@ -4935,10 +4927,6 @@
   },
   {
     "type": "do",
-    "named": false
-  },
-  {
-    "type": "double",
     "named": false
   },
   {
@@ -5007,11 +4995,11 @@
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "fn",
@@ -5075,10 +5063,6 @@
   },
   {
     "type": "integer",
-    "named": false
-  },
-  {
-    "type": "integer",
     "named": true
   },
   {
@@ -5118,10 +5102,6 @@
     "named": true
   },
   {
-    "type": "object",
-    "named": false
-  },
-  {
     "type": "or",
     "named": false
   },
@@ -5147,10 +5127,6 @@
   },
   {
     "type": "public",
-    "named": false
-  },
-  {
-    "type": "real",
     "named": false
   },
   {
@@ -5183,11 +5159,11 @@
   },
   {
     "type": "string",
-    "named": true
+    "named": false
   },
   {
     "type": "string",
-    "named": false
+    "named": true
   },
   {
     "type": "switch",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1121,6 +1121,14 @@
             "named": true
           },
           {
+            "type": "include_expression",
+            "named": true
+          },
+          {
+            "type": "include_once_expression",
+            "named": true
+          },
+          {
             "type": "unary_op_expression",
             "named": true
           }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1206,6 +1206,13 @@ list('k' => &$v) = $x;
 
 ['k' => &$v] = $x;
 
+class A {
+    function foo() {
+        $this->a = 3;
+        return [&$this->a];
+    }
+}
+
 ---
 
 (program
@@ -1404,6 +1411,38 @@ list('k' => &$v) = $x;
         (by_ref (variable_name (name)))
       )
       (variable_name (name))
+    )
+  )
+  (class_declaration
+    (name)
+    (declaration_list
+      (method_declaration
+        (name)
+        (formal_parameters)
+        (compound_statement
+          (expression_statement
+            (assignment_expression
+              (member_access_expression
+                (variable_name (name))
+                (name)
+              )
+              (integer)
+            )
+          )
+          (return_statement
+            (array_creation_expression
+              (array_element_initializer
+                (by_ref
+                  (member_access_expression
+                    (variable_name (name))
+                    (name)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
     )
   )
 )

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -145,6 +145,28 @@ Cast expressions in assignments
       (cast_expression (cast_type) (variable_name (name)))
       (integer))))
 
+=================================
+Cast include
+=================================
+
+<?php
+$a = (array) include 'some.php';
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (cast_expression
+        type: (cast_type)
+        value: (include_expression (string))
+      )
+    )
+  )
+)
+
 ==========================
 Reserved words as function calls
 ==========================


### PR DESCRIPTION
Fixes #107 by adding missing child options to the `by_ref` node
Fixes #103 by allowing casting of `include` and `include_once`
Fixes #100 by adding missing keywords to the parser

I've no idea why these changes resulted in a significantly reduced state count, but it's a really nice bonus!

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2665, PR: 2301)
