### PR TITLE
Fixes Parse error for some attribute cases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -423,6 +423,7 @@ module.exports = grammar({
     ),
 
     arrow_function: $ => seq(
+      optional(field('attributes', $.attribute_list)),
       optional($.static_modifier),
       keyword('fn'),
       optional(field('reference_modifier', $.reference_modifier)),
@@ -885,6 +886,7 @@ module.exports = grammar({
     ),
 
     anonymous_function_creation_expression: $ => seq(
+      optional(field('attributes', $.attribute_list)),
       optional(keyword('static')),
       keyword('function'),
       optional(field('reference_modifier', $.reference_modifier)),
@@ -910,6 +912,7 @@ module.exports = grammar({
       ),
       seq(
         keyword('new'),
+        optional(field('attributes', $.attribute_list)),
         keyword('class'),
         optional($.arguments),
         optional($.base_clause),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2076,6 +2076,22 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "FIELD",
+              "name": "attributes",
+              "content": {
+                "type": "SYMBOL",
+                "name": "attribute_list"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "SYMBOL",
               "name": "static_modifier"
             },
@@ -4579,6 +4595,22 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "FIELD",
+              "name": "attributes",
+              "content": {
+                "type": "SYMBOL",
+                "name": "attribute_list"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
@@ -4793,6 +4825,22 @@
                 },
                 "named": false,
                 "value": "new"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "attributes",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "attribute_list"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               },
               {
                 "type": "ALIAS",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -342,6 +342,16 @@
     "type": "anonymous_function_creation_expression",
     "named": true,
     "fields": {
+      "attributes": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "attribute_list",
+            "named": true
+          }
+        ]
+      },
       "body": {
         "multiple": false,
         "required": true,
@@ -510,6 +520,16 @@
     "type": "arrow_function",
     "named": true,
     "fields": {
+      "attributes": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "attribute_list",
+            "named": true
+          }
+        ]
+      },
       "body": {
         "multiple": false,
         "required": true,
@@ -3256,7 +3276,18 @@
   {
     "type": "object_creation_expression",
     "named": true,
-    "fields": {},
+    "fields": {
+      "attributes": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "attribute_list",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -351,6 +351,9 @@ class Thing
 {
 }
 
+new #[ExampleAttribute] class() {};
+#[ExampleAttribute] fn($x) => $x;
+$baz = #[ExampleAttribute] function($x) {return $x;};
 
 ---
 
@@ -464,6 +467,42 @@ class Thing
     )
     name: (name)
     body: (declaration_list)
+  )
+  (expression_statement
+    (object_creation_expression
+      attributes: (attribute_list (attribute (name)))
+      (arguments)
+      (declaration_list)
+    )
+  )
+  (expression_statement
+    (arrow_function
+      attributes: (attribute_list (attribute (name)))
+      parameters: (formal_parameters
+        (simple_parameter
+          name: (variable_name (name))
+        )
+      )
+      body: (variable_name (name))
+    )
+  )
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (anonymous_function_creation_expression
+        attributes: (attribute_list (attribute (name)))
+        parameters: (formal_parameters
+          (simple_parameter
+            name: (variable_name (name))
+          )
+        )
+        body: (compound_statement
+          (return_statement
+            (variable_name (name))
+          )
+        )
+      )
+    )
   )
 )
 


### PR DESCRIPTION
Fixes parsing of attributes with anonymous class, closures, and arrow functions'. The problem was an incomplete attributes implementation.



Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2301, PR: 2519)
