### PR TITLE
fix digit escape in highlight regex for constants

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -43,7 +43,7 @@
 (relative_scope) @variable.builtin
 
 ((name) @constant
- (#match? @constant "^_?[A-Z][A-Z\d_]+$"))
+ (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))
 
 ((name) @constructor
  (#match? @constructor "^[A-Z]"))

--- a/test/highlight/literals.php
+++ b/test/highlight/literals.php
@@ -11,3 +11,6 @@ echo true, TRUE, false, FALSE
 //          ^ constant.builtin
 //               ^ constant.builtin
 //                      ^ constant.builtin
+
+echo PI_314
+//   ^ constant


### PR DESCRIPTION
<details><summary>Checklist: (:heavy_check_mark:)</summary>

- [x] All tests pass in CI (they pass locally but I can't get the Actions CI running right now :thinking:)
- [x] There are sufficient tests for the new fix/feature (added one)
- [x] Grammar rules have not been renamed unless absolutely necessary (N/A)
- [x] The conflicts section hasn't grown too much (N/A)
- [x] The parser size hasn't grown too much (N/A)

</details>

This is the same idea as https://github.com/tree-sitter/tree-sitter-java/pull/90, the `\d` should be `\\d` to become the digit escape.

This one is a bit more straightforward: the query currently misconstrues constants with digits in them as constructors (because of the rule below it).

**pi.php**

```php
<?php
define("PI", 3);
define("PI_314", 3.14);
echo PI;
echo PI_314;
?>
```

**query1.scm**

```scm
((name) @constant
 (#match? @constant "^_?[A-Z][A-Z\d_]+$"))
```

**query2.scm**

```scm
((name) @constant
 (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))
```

**reproduction**

```
$ tree-sitter query query1.scm pi.php
pi.php
  pattern: 0
    capture: constant, start: (3, 5), text: "PI"

$ tree-sitter query query2.scm pi.php
pi.php
  pattern: 0
    capture: constant, start: (3, 5), text: "PI"
  pattern: 0
    capture: constant, start: (4, 5), text: "PI_314"

```
