### PR TITLE
Fixes #113 - avoid binary string rule breaking encapsed string

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1235,19 +1235,20 @@ module.exports = grammar({
           $._simple_string_part,
           $._complex_string_part,
           alias('\\u', $.string),
+          alias("'", $.string) // Needed to avoid the edge case "$b'" from breaking parsing by trying to apply the $.string rule for some reason
         ),
       ),
       '"',
     )),
 
-    string: $ => token(seq(
+    string: $ => seq(
       choice(
         /[bB]'/,
         "'"
       ),
-      repeat(/\\'|\\\\|\\?[^'\\]/),
+      token(prec(1, repeat(/\\'|\\\\|\\?[^'\\]/))), // prec(1, ...) is needed to avoid conflict with $.comment
       "'",
-    )),
+    ),
 
     boolean: $ => /[Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee]/,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6861,6 +6861,15 @@
                   },
                   "named": true,
                   "value": "string"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "'"
+                  },
+                  "named": true,
+                  "value": "string"
                 }
               ]
             }
@@ -6873,36 +6882,40 @@
       }
     },
     "string": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "[bB]'"
-              },
-              {
-                "type": "STRING",
-                "value": "'"
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "PATTERN",
-              "value": "\\\\'|\\\\\\\\|\\\\?[^'\\\\]"
+              "value": "[bB]'"
+            },
+            {
+              "type": "STRING",
+              "value": "'"
             }
-          },
-          {
-            "type": "STRING",
-            "value": "'"
+          ]
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "REPEAT",
+              "content": {
+                "type": "PATTERN",
+                "value": "\\\\'|\\\\\\\\|\\\\?[^'\\\\]"
+              }
+            }
           }
-        ]
-      }
+        },
+        {
+          "type": "STRING",
+          "value": "'"
+        }
+      ]
     },
     "boolean": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4060,6 +4060,11 @@
     }
   },
   {
+    "type": "string",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "subscript_expression",
     "named": true,
     "fields": {},
@@ -4701,6 +4706,10 @@
     "named": false
   },
   {
+    "type": "'",
+    "named": false
+  },
+  {
     "type": "(",
     "named": false
   },
@@ -5026,11 +5035,11 @@
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "fn",
@@ -5126,11 +5135,11 @@
   },
   {
     "type": "null",
-    "named": false
+    "named": true
   },
   {
     "type": "null",
-    "named": true
+    "named": false
   },
   {
     "type": "or",
@@ -5191,10 +5200,6 @@
   {
     "type": "string",
     "named": false
-  },
-  {
-    "type": "string",
-    "named": true
   },
   {
     "type": "switch",

--- a/test/corpus/string.txt
+++ b/test/corpus/string.txt
@@ -601,6 +601,12 @@ okay to do';
 'You deleted C:\*.*?';
 'This will not expand: \n a newline';
 'Variables do not $expand $either';
+'socket://';
+'#valid regexp#';
+'hello#world';
+'hello//world';
+'/*valid regexp*/';
+'/*valid regexp';
 
 ---
 
@@ -613,4 +619,37 @@ okay to do';
   (expression_statement (string))
   (expression_statement (string))
   (expression_statement (string))
+  (expression_statement (string))
+  (expression_statement (string))
+  (expression_statement (string))
+  (expression_statement (string))
+  (expression_statement (string))
+  (expression_statement (string))
 )
+
+=========================================
+Bug: #113 
+=========================================
+
+<?php
+"$b'";
+"'";
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (encapsed_string
+      (variable_name (name))
+      (string)
+    )
+  )
+  (expression_statement
+    (encapsed_string
+      (string)
+    )
+  )
+)
+
+


### PR DESCRIPTION
Avoid binary string rule breaking encapsed string when containing $b'

See #113 for problem details.

## Solution:

- Adding higher precedence to the content of $.string in order to avoid conflict with $.comment which is globally invoked by extras.
- Hack: Adding alias("'", $.string) to encapsed_string in order to avoid matching with the $.string rule (a more elegant solution would be very welcome)


Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2519, PR: 2526)
