### PR TITLE
Replaces type_list with union_type everywhere except for in catch_clause

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -422,13 +422,17 @@ module.exports = grammar({
       optional($._return_type)
     ),
 
-    arrow_function: $ => seq(
+    _arrow_function_header: $ => seq(
       optional(field('attributes', $.attribute_list)),
       optional($.static_modifier),
       keyword('fn'),
       optional(field('reference_modifier', $.reference_modifier)),
       field('parameters', $.formal_parameters),
       optional($._return_type),
+    ),
+
+    arrow_function: $ => seq(
+      $._arrow_function_header,
       '=>',
       field('body', $._expression)
     ),
@@ -469,7 +473,7 @@ module.exports = grammar({
       field('name', $.variable_name)
     ),
 
-    _type: $ => alias($.union_type, $.type_list),
+    _type: $ => $.union_type,
 
     _types: $ => choice(
       $.optional_type,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2069,7 +2069,7 @@
         }
       ]
     },
-    "arrow_function": {
+    "_arrow_function_header": {
       "type": "SEQ",
       "members": [
         {
@@ -2144,6 +2144,15 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "arrow_function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_function_header"
         },
         {
           "type": "STRING",
@@ -2457,13 +2466,8 @@
       ]
     },
     "_type": {
-      "type": "ALIAS",
-      "content": {
-        "type": "SYMBOL",
-        "name": "union_type"
-      },
-      "named": true,
-      "value": "type_list"
+      "type": "SYMBOL",
+      "name": "union_type"
     },
     "_types": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -328,7 +328,7 @@
     "named": true,
     "subtypes": [
       {
-        "type": "type_list",
+        "type": "union_type",
         "named": true
       }
     ]
@@ -4306,14 +4306,6 @@
         {
           "type": "named_type",
           "named": true
-        },
-        {
-          "type": "optional_type",
-          "named": true
-        },
-        {
-          "type": "primitive_type",
-          "named": true
         }
       ]
     }
@@ -4332,6 +4324,29 @@
         },
         {
           "type": "integer",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "union_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "named_type",
+          "named": true
+        },
+        {
+          "type": "optional_type",
+          "named": true
+        },
+        {
+          "type": "primitive_type",
           "named": true
         }
       ]
@@ -5035,11 +5050,11 @@
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "fn",
@@ -5135,11 +5150,11 @@
   },
   {
     "type": "null",
-    "named": true
+    "named": false
   },
   {
     "type": "null",
-    "named": false
+    "named": true
   },
   {
     "type": "or",

--- a/test/corpus/class.txt
+++ b/test/corpus/class.txt
@@ -321,18 +321,18 @@ class A {
     body: (declaration_list
       (property_declaration
         (visibility_modifier)
-        type: (type_list (primitive_type))
+        type: (union_type (primitive_type))
         (property_element (variable_name (name)))
       )
       (property_declaration
         (visibility_modifier)
         (static_modifier)
-        type: (type_list (named_type (name)))
+        type: (union_type (named_type (name)))
         (property_element (variable_name (name)))
       )
       (property_declaration
         (visibility_modifier)
-        type: (type_list (optional_type (primitive_type)))
+        type: (union_type (optional_type (primitive_type)))
         (property_element (variable_name (name)))
       )
       (property_declaration
@@ -371,20 +371,20 @@ class Point {
         parameters: (formal_parameters
           (property_promotion_parameter
             visibility: (visibility_modifier)
-            type: (type_list
+            type: (union_type
               (primitive_type)
             )
             name: (variable_name (name))
             default_value: (float)
           )
           (simple_parameter
-            type: (type_list (primitive_type))
+            type: (union_type (primitive_type))
             name: (variable_name (name))
             default_value: (float)
           )
           (property_promotion_parameter
             visibility: (visibility_modifier)
-            type: (type_list (primitive_type))
+            type: (union_type (primitive_type))
             name: (variable_name (name))
             default_value: (float)
           )

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -197,10 +197,10 @@ function test(int $a, string ...$b)
 		name: (name)
 		parameters: (formal_parameters
 			(simple_parameter
-				type: (type_list (primitive_type))
+				type: (union_type (primitive_type))
 				name: (variable_name (name)))
 			(variadic_parameter
-				type: (type_list (primitive_type))
+				type: (union_type (primitive_type))
 				name: (variable_name (name))))
 		body: (compound_statement)))
 
@@ -383,7 +383,7 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
       (property_declaration
         attributes: (attribute_list (attribute (name)))
         (visibility_modifier)
-        type: (type_list (primitive_type))
+        type: (union_type (primitive_type))
         (property_element (variable_name (name))
           (property_initializer (string))
         )
@@ -552,13 +552,13 @@ enum Suit: string
   )
   (enum_declaration
     (name)
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (class_interface_clause (name))
     (enum_declaration_list)
   )
   (enum_declaration
     (name)
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (enum_declaration_list 
       (enum_case (name) (string))
       (enum_case (name))
@@ -571,7 +571,7 @@ enum Suit: string
         (visibility_modifier)
         (name)
         (formal_parameters)
-        (type_list (primitive_type))
+        (union_type (primitive_type))
         (compound_statement
           (return_statement
             (match_expression

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1071,7 +1071,7 @@ $fn1 = fn($x) => $x + $y;
     (arrow_function
       parameters: (formal_parameters
         (simple_parameter
-          type: (type_list (primitive_type))
+          type: (union_type (primitive_type))
           name: (variable_name (name))
         )
       )
@@ -1120,7 +1120,7 @@ $fn1 = fn($x) => $x + $y;
   (expression_statement
     (arrow_function
       parameters: (formal_parameters)
-      return_type: (type_list (primitive_type))
+      return_type: (union_type (primitive_type))
       body: (variable_name (name))
     )
   )
@@ -1271,7 +1271,7 @@ class A {
         (variable_name (name))
       )
       (variadic_parameter
-        (type_list (named_type (name)))
+        (union_type (named_type (name)))
         (reference_modifier)
         (variable_name (name))
       )

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -12,11 +12,11 @@ function b(): A\B {}
   (php_tag)
   (function_definition
     (name) (formal_parameters)
-    (type_list (named_type (name)))
+    (union_type (named_type (name)))
     (compound_statement))
   (function_definition
     (name) (formal_parameters)
-    (type_list
+    (union_type
       (named_type (qualified_name (namespace_name_as_prefix (namespace_name (name))) (name)))
     )
     (compound_statement)))
@@ -36,15 +36,15 @@ function c(): iterable {}
   (php_tag)
   (function_definition
     (name) (formal_parameters)
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (compound_statement))
   (function_definition
     (name) (formal_parameters)
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (compound_statement))
   (function_definition
     (name) (formal_parameters)
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (compound_statement)))
 
 =======================
@@ -62,13 +62,13 @@ function b(): ?Something {}
   (php_tag)
   (function_definition
     (name) (formal_parameters)
-    (type_list
+    (union_type
       (optional_type (primitive_type))
     )
     (compound_statement))
   (function_definition
     (name) (formal_parameters)
-    (type_list
+    (union_type
       (optional_type (named_type (name)))
     )
     (compound_statement)))
@@ -90,7 +90,7 @@ function a(int|string|null $var) : ?int|MyClass {}
     name: (name)
     parameters: (formal_parameters
       (simple_parameter
-        type: (type_list
+        type: (union_type
           (primitive_type)
           (primitive_type)
           (primitive_type)
@@ -98,7 +98,7 @@ function a(int|string|null $var) : ?int|MyClass {}
         name: (variable_name (name))
       )
     )
-    return_type: (type_list
+    return_type: (union_type
       (optional_type
         (primitive_type)
       )
@@ -125,14 +125,14 @@ function a(mixed|string $var) : mixed {
     (name)
     (formal_parameters
       (simple_parameter
-        (type_list
+        (union_type
           (primitive_type)
           (primitive_type)
         )
         (variable_name (name))
       )
     )
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (compound_statement)
   )
 )
@@ -154,13 +154,13 @@ function a(string $var) : static {
     (name)
     (formal_parameters
       (simple_parameter
-        (type_list
+        (union_type
           (primitive_type)
         )
         (variable_name (name))
       )
     )
-    (type_list (primitive_type))
+    (union_type (primitive_type))
     (compound_statement)
   )
 )


### PR DESCRIPTION
## Description
1. Replaces type_list with union_type everywhere except for in catch_clause to be more in line with the actual terminology in PHP
2. Reduces state count from 2519 to 2323 by reducing the combinatorial explosion I've caused when implementing other rules
3. ~~Reduces execution time of full test suite from 4-5 minutes to 46 s - 1 min by only doing shallow checkouts of repositories~~ - **Scratch that, I just realized that the tests are failing silently. Improvement coming in later PR**

## Note
This is a backwards incompatible change compared with code that's been in master since April 19th, but is not yet part of any release

## Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [ ] Grammar rules have not been renamed unless absolutely necessary (1 rule renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2519, PR: 2323)
