### PR TITLE
use explicit typing for lexer lookahead

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -118,7 +118,7 @@ struct Scanner {
   static bool is_escapable_sequence(TSLexer *lexer) {
     // Note: remember to also update the escape_sequence rule in the
     // main grammar whenever changing this method
-    auto letter = lexer->lookahead;
+    int32_t letter = lexer->lookahead;
 
     if (letter == 'n' ||
         letter == 'r' ||


### PR DESCRIPTION
Checklist: ✅ 
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature (N/A)
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2330, PR: 2330)

👋 hello!

The `auto` typing is problematic for older c++ toolchains. In my case, it fails to cross-compile from x86_64-linux to aarch64-linux because of an old compiler. Declaring the type explicitly works fine though. What do you think?