### PR TITLE
Adds attribute_group node to complete attributes support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1163,11 +1163,14 @@ module.exports = grammar({
       seq('[', commaSep($.array_element_initializer), optional(','), ']')
     ),
 
-    attribute_list: $ => repeat1(seq(
+    attribute_group: $ => seq(
       '#[',
       commaSep1($.attribute),
+      optional(','),
       ']',
-    )),
+    ),
+
+    attribute_list: $ => repeat1($.attribute_group),
 
     attribute: $ => seq(
       choice($.name, alias($._reserved_identifier, $.name), $.qualified_name),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6499,45 +6499,61 @@
         }
       ]
     },
+    "attribute_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "attribute"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "attribute"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
     "attribute_list": {
       "type": "REPEAT1",
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "#["
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "attribute"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "attribute"
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "]"
-          }
-        ]
+        "type": "SYMBOL",
+        "name": "attribute_group"
       }
     },
     "attribute": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -683,7 +683,7 @@
     }
   },
   {
-    "type": "attribute_list",
+    "type": "attribute_group",
     "named": true,
     "fields": {},
     "children": {
@@ -692,6 +692,21 @@
       "types": [
         {
           "type": "attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "attribute_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_group",
           "named": true
         }
       ]
@@ -5044,11 +5059,11 @@
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "fn",
@@ -5144,11 +5159,11 @@
   },
   {
     "type": "null",
-    "named": false
+    "named": true
   },
   {
     "type": "null",
-    "named": true
+    "named": false
   },
   {
     "type": "or",

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -355,17 +355,37 @@ new #[ExampleAttribute] class() {};
 #[ExampleAttribute] fn($x) => $x;
 $baz = #[ExampleAttribute] function($x) {return $x;};
 
+class A {
+  #[\Assert\All(
+      new \Assert\NotNull,
+      new \Assert\Length(min: 5))
+  ]
+  public string $name = '';
+
+}
+
+#[
+    A1,
+    A2(),
+    A3(0),
+    A4(x: 1),
+]
+function a() {
+}
+
 ---
 
 (program
   (php_tag)
 
   (function_definition
-    attributes: (attribute_list (attribute (name)))
+    attributes: (attribute_list (attribute_group (attribute (name))))
     name: (name)
     parameters: (formal_parameters
       (simple_parameter
-        attributes: (attribute_list (attribute (name)))
+        attributes: (attribute_list 
+          (attribute_group (attribute (name)))
+        )
         name: (variable_name (name))
       )
     )
@@ -376,12 +396,12 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
     name: (name)
     body: (declaration_list
       (const_declaration
-        attributes: (attribute_list (attribute (name)))
+        attributes: (attribute_list (attribute_group (attribute (name))))
         (const_element (name) (string))
       )
 
       (property_declaration
-        attributes: (attribute_list (attribute (name)))
+        attributes: (attribute_list (attribute_group (attribute (name))))
         (visibility_modifier)
         type: (union_type (primitive_type))
         (property_element (variable_name (name))
@@ -390,13 +410,15 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
       )
       (method_declaration
         attributes: (attribute_list
-          (attribute
-            (name)
-            parameters: (arguments
-              (argument (encapsed_string (string)))
-              (argument
-                (array_creation_expression
-                  (array_element_initializer (encapsed_string (string)))
+          (attribute_group
+            (attribute
+              (name)
+              parameters: (arguments
+                (argument (encapsed_string (string)))
+                (argument
+                  (array_creation_expression
+                    (array_element_initializer (encapsed_string (string)))
+                  )
                 )
               )
             )
@@ -406,7 +428,7 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
         name: (name)
         parameters: (formal_parameters
           (simple_parameter
-            attributes: (attribute_list (attribute (name)))
+            attributes: (attribute_list (attribute_group (attribute (name))))
             name: (variable_name (name))
           )
         )
@@ -416,50 +438,62 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
   )
   (class_declaration
     attributes: (attribute_list
-      (attribute (name))
-      (attribute
-        (qualified_name
-          (namespace_name_as_prefix
-            (namespace_name (name))
-          )
-          (name)
-        )
+      (attribute_group
+        (attribute (name))
       )
-      (attribute
-        (name)
-        parameters: (arguments (argument (integer)))
-      )
-      (attribute
-        (name)
-        parameters: (arguments
-          (argument
-            (class_constant_access_expression
-              (name)
-              (name)
+      (attribute_group
+        (attribute
+          (qualified_name
+            (namespace_name_as_prefix
+              (namespace_name (name))
             )
+            (name)
           )
         )
       )
-      (attribute
-        (name)
-        parameters: (arguments
-          (argument
-            (array_creation_expression
-              (array_element_initializer
-                (encapsed_string (string))
-                (encapsed_string (string))
+      (attribute_group
+        (attribute
+          (name)
+          parameters: (arguments (argument (integer)))
+        )
+      )
+      (attribute_group
+        (attribute
+          (name)
+          parameters: (arguments
+            (argument
+              (class_constant_access_expression
+                (name)
+                (name)
               )
             )
           )
         )
       )
-      (attribute
-        (name)
-        parameters: (arguments
-          (argument
-            (binary_expression
-              left: (integer)
-              right: (integer)
+      (attribute_group
+        (attribute
+          (name)
+          parameters: (arguments
+            (argument
+              (array_creation_expression
+                (array_element_initializer
+                  (encapsed_string (string))
+                  (encapsed_string (string))
+                )
+              )
+            )
+          )
+        )
+      )
+      (attribute_group
+        (attribute
+          (name)
+          parameters: (arguments
+            (argument
+              (binary_expression
+                left: (integer)
+                right: (integer)
+              )
             )
           )
         )
@@ -470,14 +504,14 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
   )
   (expression_statement
     (object_creation_expression
-      attributes: (attribute_list (attribute (name)))
+      attributes: (attribute_list (attribute_group (attribute (name))))
       (arguments)
       (declaration_list)
     )
   )
   (expression_statement
     (arrow_function
-      attributes: (attribute_list (attribute (name)))
+      attributes: (attribute_list (attribute_group (attribute (name))))
       parameters: (formal_parameters
         (simple_parameter
           name: (variable_name (name))
@@ -490,7 +524,7 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
     (assignment_expression
       left: (variable_name (name))
       right: (anonymous_function_creation_expression
-        attributes: (attribute_list (attribute (name)))
+        attributes: (attribute_list (attribute_group (attribute (name))))
         parameters: (formal_parameters
           (simple_parameter
             name: (variable_name (name))
@@ -503,6 +537,75 @@ $baz = #[ExampleAttribute] function($x) {return $x;};
         )
       )
     )
+  )
+  (class_declaration
+    name: (name)
+    body: (declaration_list
+      (property_declaration
+        attributes: (attribute_list
+          (attribute_group
+            (attribute
+              (qualified_name
+                (namespace_name_as_prefix (namespace_name (name)))
+                (name)
+              )
+              parameters: (arguments
+                (argument
+                  (object_creation_expression
+                    (qualified_name
+                      (namespace_name_as_prefix (namespace_name (name)))
+                      (name)
+                    )
+                  )
+                )
+                (argument
+                  (object_creation_expression
+                    (qualified_name
+                      (namespace_name_as_prefix (namespace_name (name)))
+                      (name)
+                    )
+                    (arguments
+                      (argument
+                        name: (name)
+                        (integer)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (visibility_modifier)
+        type: (union_type (primitive_type))
+        (property_element
+          (variable_name (name))
+          (property_initializer (string))
+        )
+      )
+    )
+  )
+  (function_definition
+    attributes: (attribute_list
+      (attribute_group
+        (attribute (name))
+        (attribute
+          (name)
+          parameters: (arguments)
+        )
+        (attribute
+          (name)
+          parameters: (arguments (argument (integer)))
+        )
+        (attribute
+          (name)
+          parameters: (arguments (argument name: (name) (integer)))
+        )
+      )
+    )
+    name: (name)
+    parameters: (formal_parameters)
+    body: (compound_statement)
   )
 )
 


### PR DESCRIPTION
Also fixes a bug with missing support for trailing comma in attribute listings

This changes the node structure for currently unreleased code.

### Example

Code:
```
#[
    A1,
    A2(),
    A3(0),
    A4(x: 1),
]
function a() {
}
```

Before:

```
(function_definition
    attributes: (attribute_list
        (attribute (name))
        (attribute
          (name)
          parameters: (arguments)
        )
        (attribute
          (name)
          parameters: (arguments (argument (integer)))
        )
        (attribute
          (name)
          parameters: (arguments (argument name: (name) (integer)))
        )
    )
    name: (name)
    parameters: (formal_parameters)
    body: (compound_statement)
  )
```


After:
```
(function_definition
    attributes: (attribute_list
      (attribute_group
        (attribute (name))
        (attribute
          (name)
          parameters: (arguments)
        )
        (attribute
          (name)
          parameters: (arguments (argument (integer)))
        )
        (attribute
          (name)
          parameters: (arguments (argument name: (name) (integer)))
        )
      )
    )
    name: (name)
    parameters: (formal_parameters)
    body: (compound_statement)
  )
```

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2330, PR: 2338)
