### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples
 *.o
 bindings/c/*.h
 bindings/c/tree-sitter-*.pc
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterPHP",
+    products: [
+        .library(name: "TreeSitterPHP", targets: ["TreeSitterPHP"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterPHP",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "README.md",
+                    "script",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterPHP/php.h
+++ b/bindings/swift/TreeSitterPHP/php.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_PHP_H_
+#define TREE_SITTER_PHP_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_php();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_PHP_H_ 


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.
