### PR TITLE
Parse readonly properties

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -298,6 +298,7 @@ module.exports = grammar({
 
     final_modifier: $ => keyword('final'),
     abstract_modifier: $ => keyword('abstract'),
+    readonly_modifier: $ => keyword('readonly'),
 
     class_interface_clause: $ => seq(
       keyword('implements'),
@@ -339,7 +340,8 @@ module.exports = grammar({
       $.visibility_modifier,
       $.static_modifier,
       $.final_modifier,
-      $.abstract_modifier
+      $.abstract_modifier,
+      $.readonly_modifier
     )),
 
     property_element: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1298,6 +1298,15 @@
       "named": false,
       "value": "abstract"
     },
+    "readonly_modifier": {
+      "type": "ALIAS",
+      "content": {
+        "type": "PATTERN",
+        "value": "[rR][eE][aA][dD][oO][nN][lL][yY]"
+      },
+      "named": false,
+      "value": "readonly"
+    },
     "class_interface_clause": {
       "type": "SEQ",
       "members": [
@@ -1597,6 +1606,10 @@
           {
             "type": "SYMBOL",
             "name": "abstract_modifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "readonly_modifier"
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2848,6 +2848,10 @@
           "named": true
         },
         {
+          "type": "readonly_modifier",
+          "named": true
+        },
+        {
           "type": "static_modifier",
           "named": true
         },
@@ -3494,6 +3498,10 @@
           "named": true
         },
         {
+          "type": "readonly_modifier",
+          "named": true
+        },
+        {
           "type": "static_modifier",
           "named": true
         },
@@ -3606,6 +3614,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "readonly_modifier",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "reference_assignment_expression",
@@ -5191,6 +5204,10 @@
   },
   {
     "type": "public",
+    "named": false
+  },
+  {
+    "type": "readonly",
     "named": false
   },
   {

--- a/test/corpus/class.txt
+++ b/test/corpus/class.txt
@@ -394,3 +394,339 @@ class Point {
     )
   )
 )
+
+================================================================================
+Readonly properties
+================================================================================
+
+<?php
+class A {
+    private readonly int $pria;
+    private readonly float $prfa;
+    private readonly mixed $prma;
+    private readonly string $prsa;
+    private readonly object $proa;
+    readonly private int $rpia;
+    readonly private float $rpfa;
+    readonly private mixed $rpma;
+    readonly private string $rpsa;
+    readonly private object $rpoa;
+
+    protected readonly int $oria;
+    protected readonly float $orfa;
+    protected readonly mixed $orma;
+    protected readonly string $orsa;
+    protected readonly object $oroa;
+    readonly protected int $roia;
+    readonly protected float $rofa;
+    readonly protected mixed $roma;
+    readonly protected string $rosa;
+    readonly protected object $rooa;
+
+    public readonly int $uria;
+    public readonly float $urfa;
+    public readonly mixed $urma;
+    public readonly string $ursa;
+    public readonly object $uroa;
+    readonly public int $ruia;
+    readonly public float $rufa;
+    readonly public mixed $ruma;
+    readonly public string $rusa;
+    readonly public object $ruoa;
+
+    readonly int $ria;
+    readonly float $rfa;
+    readonly mixed $rma;
+    ReAdOnLy string $rsa;
+    READONLY object $roa;
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (class_declaration
+    (name)
+    (declaration_list
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (visibility_modifier)
+        (readonly_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (visibility_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))))
+      (property_declaration
+        (readonly_modifier)
+        (union_type
+          (named_type
+            (name)))
+        (property_element
+          (variable_name
+            (name)))))))


### PR DESCRIPTION
E.g.
```
class A {
   public readonly string $prop;
}
```



Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2338, PR: 2340) (check the value of STATE_COUNT in src/parser.c)
