### PR TITLE
Fixes bug #131 - Parse error when using self as constant

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1109,7 +1109,7 @@ module.exports = grammar({
     argument: $ => seq(
       optional(seq(field('name', $.name), ':')),
       optional(field('reference_modifier', $.reference_modifier)),
-      choice($.variadic_unpacking, $._expression)
+      choice(alias($._reserved_identifier, $.name), $.variadic_unpacking, $._expression)
     ),
 
     member_call_expression: $ => prec(PREC.CALL, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6138,6 +6138,15 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_reserved_identifier"
+              },
+              "named": true,
+              "value": "name"
+            },
+            {
               "type": "SYMBOL",
               "name": "variadic_unpacking"
             },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -457,6 +457,10 @@
           "named": true
         },
         {
+          "type": "name",
+          "named": true
+        },
+        {
           "type": "variadic_unpacking",
           "named": true
         }

--- a/test/corpus/bugs.txt
+++ b/test/corpus/bugs.txt
@@ -1,0 +1,28 @@
+=========================================
+#131: Parse error when using self as constant
+=========================================
+
+<?php
+define('self', 'value');
+var_dump(self);
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (function_call_expression
+      function: (name)
+      arguments: (arguments
+        (argument (string))
+        (argument (string))
+      )
+    )
+  )
+  (expression_statement
+    (function_call_expression
+      function: (name)
+      arguments: (arguments (argument (name)))
+    )
+  )
+)


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2340, PR: 2344)
