### PR TITLE
Adds support for first class callable syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1099,11 +1099,18 @@ module.exports = grammar({
       keyword('static')
     )),
 
+    variadic_placeholder: $ => token('...'),
+
     arguments: $ => seq(
       '(',
-      commaSep($.argument),
-      optional(','),
-      ')'
+      choice(
+        seq(
+          commaSep($.argument),
+          optional(','),
+        ),
+        $.variadic_placeholder,
+      ),
+      ')',
     ),
 
     argument: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6032,6 +6032,13 @@
         ]
       }
     },
+    "variadic_placeholder": {
+      "type": "TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "..."
+      }
+    },
     "arguments": {
       "type": "SEQ",
       "members": [
@@ -6046,41 +6053,55 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "argument"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "argument"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "argument"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "argument"
-                      }
-                    ]
-                  }
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
             {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "variadic_placeholder"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -478,6 +478,10 @@
         {
           "type": "argument",
           "named": true
+        },
+        {
+          "type": "variadic_placeholder",
+          "named": true
         }
       ]
     }
@@ -4634,6 +4638,11 @@
     }
   },
   {
+    "type": "variadic_placeholder",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "variadic_unpacking",
     "named": true,
     "fields": {},
@@ -5176,11 +5185,11 @@
   },
   {
     "type": "null",
-    "named": true
+    "named": false
   },
   {
     "type": "null",
-    "named": false
+    "named": true
   },
   {
     "type": "or",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -980,6 +980,71 @@ $country = $session?->user?->getAddress()?->country;
   )
 )
 
+
+===============================================
+First class callable syntax
+===============================================
+
+<?php
+foo(...);
+$this->foo(...);
+A::foo(...);
+
+// These are invalid, but accepted on the parser level.
+new Foo(...);
+
+#[Foo(...)]
+function foo() {}
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (function_call_expression
+      (name)
+      (arguments (variadic_placeholder))
+    )
+  )
+  (expression_statement
+    (member_call_expression
+      (variable_name (name))
+      (name)
+      (arguments (variadic_placeholder))
+    )
+  )
+  (expression_statement
+    (scoped_call_expression
+      (name)
+      (name)
+      (arguments (variadic_placeholder))
+    )
+  )
+  
+  (comment)
+  (expression_statement
+    (object_creation_expression
+      (name)
+      (arguments (variadic_placeholder))
+    )
+  )
+  
+  (function_definition
+    (attribute_list
+      (attribute_group
+        (attribute
+          (name)
+          (arguments (variadic_placeholder))
+        )
+      )
+    )
+    (name)
+    (formal_parameters)
+    (compound_statement)
+  )
+)
+
+
 ===============================================
 Match expressions
 ===============================================


### PR DESCRIPTION
[RFC](https://wiki.php.net/rfc/first_class_callable_syntax)

[PHPParser implementation](https://github.com/nikic/PHP-Parser/commit/13549aa7949c7c453e297003b70517bf8ddcec95)

Checklist:
- [ ] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2344, PR: 2345)
