### PR TITLE
Adds support for the never return type from the no_return RFC

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -493,6 +493,8 @@ module.exports = grammar({
       )
     ),
 
+    bottom_type: $ => 'never',
+
     union_type: $ => prec.right(pipeSep1($._types)),
 
     primitive_type: $ => choice(
@@ -525,7 +527,7 @@ module.exports = grammar({
       keyword('unset', false)
     ),
 
-    _return_type: $ => seq(':', field('return_type', $._type)),
+    _return_type: $ => seq(':', field('return_type', choice($._type, $.bottom_type))),
 
     const_element: $ => seq(
       choice($.name, alias($._reserved_identifier, $.name)), '=', $._expression

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2534,6 +2534,10 @@
         }
       ]
     },
+    "bottom_type": {
+      "type": "STRING",
+      "value": "never"
+    },
     "union_type": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -2685,8 +2689,17 @@
           "type": "FIELD",
           "name": "return_type",
           "content": {
-            "type": "SYMBOL",
-            "name": "_type"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_type"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bottom_type"
+              }
+            ]
           }
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -389,6 +389,10 @@
           {
             "type": "_type",
             "named": true
+          },
+          {
+            "type": "bottom_type",
+            "named": true
           }
         ]
       }
@@ -574,6 +578,10 @@
         "types": [
           {
             "type": "_type",
+            "named": true
+          },
+          {
+            "type": "bottom_type",
             "named": true
           }
         ]
@@ -2219,6 +2227,10 @@
           {
             "type": "_type",
             "named": true
+          },
+          {
+            "type": "bottom_type",
+            "named": true
           }
         ]
       }
@@ -2838,6 +2850,10 @@
         "types": [
           {
             "type": "_type",
+            "named": true
+          },
+          {
+            "type": "bottom_type",
             "named": true
           }
         ]
@@ -4972,6 +4988,10 @@
     "named": true
   },
   {
+    "type": "bottom_type",
+    "named": true
+  },
+  {
     "type": "break",
     "named": false
   },
@@ -5085,11 +5105,11 @@
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "fn",

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -29,6 +29,7 @@ Primitive types
 function a(): int {}
 function b(): callable {}
 function c(): iterable {}
+function d(): never {}
 
 ---
 
@@ -45,6 +46,10 @@ function c(): iterable {}
   (function_definition
     (name) (formal_parameters)
     (union_type (primitive_type))
+    (compound_statement))
+  (function_definition
+    (name) (formal_parameters)
+    (bottom_type)
     (compound_statement)))
 
 =======================


### PR DESCRIPTION
This adds a new bottom_type only applicable to return types to represent the new "never" type.

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2345, PR: 2345)
