### PR TITLE
Fixes #133 - Incorrect precedence for error supression operator

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -849,7 +849,7 @@ module.exports = grammar({
     ),
 
     unary_op_expression: $ => choice(
-      seq('@', $._expression),
+      prec(PREC.INC, seq('@', $._expression)),
       prec.left(PREC.NEG, seq(choice('+', '-', '~', '!'), $._expression))
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4342,17 +4342,21 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "@"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
-          ]
+          "type": "PREC",
+          "value": 21,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "@"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
         },
         {
           "type": "PREC_LEFT",

--- a/test/corpus/bugs.txt
+++ b/test/corpus/bugs.txt
@@ -26,3 +26,42 @@ var_dump(self);
     )
   )
 )
+
+=========================================
+#133: Incorrect precedence for error supression operator
+=========================================
+
+<?php
+@trigger_error("a") && trigger_error("b");
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (binary_expression
+      left: (unary_op_expression
+        (function_call_expression
+          function: (name)
+          arguments: (arguments
+            (argument
+              (encapsed_string
+                (string)
+              )
+            )
+          )
+        )
+      )
+      right: (function_call_expression
+        function: (name)
+        arguments: (arguments
+          (argument
+            (encapsed_string
+              (string)
+            )
+          )
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2345, PR: 2343)
