### PR TITLE
Adds support for constructor property promotion with readonly modifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -448,6 +448,7 @@ module.exports = grammar({
 
     property_promotion_parameter: $ => seq(
       field('visibility', $.visibility_modifier),
+      field('readonly', optional($.readonly_modifier)),
       field('type', optional($._type)), // Note: callable is not a valid type here, but instead of complicating the parser, we defer this checking to any intelligence using the parser
       field('name', $.variable_name),
       optional(seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2278,6 +2278,22 @@
         },
         {
           "type": "FIELD",
+          "name": "readonly",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "readonly_modifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
           "name": "type",
           "content": {
             "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3598,6 +3598,16 @@
           }
         ]
       },
+      "readonly": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "readonly_modifier",
+            "named": true
+          }
+        ]
+      },
       "type": {
         "multiple": false,
         "required": false,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/test/corpus/class.txt
+++ b/test/corpus/class.txt
@@ -730,3 +730,41 @@ class A {
         (property_element
           (variable_name
             (name)))))))
+
+================================================================================
+Constructor property promotion with readonly modifier
+================================================================================
+
+<?php
+class Point {
+    public function __construct(
+        public $x,
+        protected readonly $y,
+        private readonly int $z,
+    ) {}
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (name)
+    body: (declaration_list
+      (method_declaration
+        (visibility_modifier)
+        name: (name)
+        parameters: (formal_parameters
+          (property_promotion_parameter
+            visibility: (visibility_modifier)
+            name: (variable_name (name)))
+          (property_promotion_parameter
+            visibility: (visibility_modifier)
+            readonly: (readonly_modifier)
+            name: (variable_name (name)))
+          (property_promotion_parameter
+            visibility: (visibility_modifier)
+            readonly: (readonly_modifier)
+            type: (union_type (primitive_type))
+            name: (variable_name (name))))
+        body: (compound_statement)))))


### PR DESCRIPTION
Adds support for constructor property promotion with readonly modifiers:

```php
// test/corpus/class.txt

<?php
class Point {
    public function __construct(
        public $x,
        protected readonly $y,
        private readonly int $z,
    ) {}
}
```



Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2343, PR: 2352) (check the value of STATE_COUNT in src/parser.c)
