### PR TITLE
Adds support for interpolation in execution operators. Closes #135

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5089,125 +5089,6 @@
         ]
       }
     },
-    "shell_command_expression": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "`"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "\\\\\"|\\\\\\\\|\\\\\\$|\\\\e|\\\\f|\\\\n|\\\\r|\\\\t|\\\\v"
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "PATTERN",
-                          "value": "[0-7]"
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "PATTERN",
-                              "value": "[0-7]"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "PATTERN",
-                              "value": "[0-7]"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\\\[xX]"
-                        },
-                        {
-                          "type": "PATTERN",
-                          "value": "\\d|a-f|A-F"
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "PATTERN",
-                              "value": "\\d|a-f|A-F"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\u{"
-                        },
-                        {
-                          "type": "REPEAT1",
-                          "content": {
-                            "type": "PATTERN",
-                            "value": "\\d|a-f|A-F"
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[^`\\\\]|\\\\[^`\\\\$efnrtv0-7]"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "`"
-          }
-        ]
-      }
-    },
     "cast_expression": {
       "type": "PREC",
       "value": -1,
@@ -6910,6 +6791,10 @@
                 "value": "\""
               },
               {
+                "type": "STRING",
+                "value": "`"
+              },
+              {
                 "type": "PATTERN",
                 "value": "[0-7]{1,3}"
               },
@@ -7436,6 +7321,87 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "_interpolated_execution_operator_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "escape_sequence"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_name"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "execution_string_chars_after_variable"
+                },
+                "named": true,
+                "value": "string_value"
+              }
+            ]
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "execution_string_chars"
+            },
+            "named": true,
+            "value": "string_value"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_simple_string_part"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_complex_string_part"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "\\u"
+            },
+            "named": true,
+            "value": "string_value"
+          }
+        ]
+      }
+    },
+    "shell_command_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "`"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_interpolated_execution_operator_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "`"
         }
       ]
     },
@@ -8884,6 +8850,14 @@
     {
       "type": "SYMBOL",
       "name": "encapsed_string_chars_after_variable"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "execution_string_chars"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "execution_string_chars_after_variable"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4222,6 +4222,45 @@
     }
   },
   {
+    "type": "shell_command_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "dynamic_variable_name",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "member_access_expression",
+          "named": true
+        },
+        {
+          "type": "string_value",
+          "named": true
+        },
+        {
+          "type": "subscript_expression",
+          "named": true
+        },
+        {
+          "type": "variable_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "simple_parameter",
     "named": true,
     "fields": {
@@ -5185,6 +5224,10 @@
     "named": false
   },
   {
+    "type": "`",
+    "named": false
+  },
+  {
     "type": "abstract",
     "named": false
   },
@@ -5326,11 +5369,11 @@
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "fn",
@@ -5434,11 +5477,11 @@
   },
   {
     "type": "null",
-    "named": false
+    "named": true
   },
   {
     "type": "null",
-    "named": true
+    "named": false
   },
   {
     "type": "or",
@@ -5487,10 +5530,6 @@
   {
     "type": "self",
     "named": false
-  },
-  {
-    "type": "shell_command_expression",
-    "named": true
   },
   {
     "type": "static",

--- a/test/corpus/execution_operator.txt
+++ b/test/corpus/execution_operator.txt
@@ -1,0 +1,190 @@
+================================================================================
+Quotes in backticks
+================================================================================
+
+<?php
+`"'`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (shell_command_expression
+      (string_value))))
+
+================================================================================
+Escape sequences in backticks
+================================================================================
+
+<?php
+`echo hello\nworld`;
+`\x6c\x73`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (shell_command_expression
+      (string_value)
+      (escape_sequence)
+      (string_value)))
+  (expression_statement
+    (shell_command_expression
+      (escape_sequence)
+      (escape_sequence))))
+
+================================================================================
+Variable interpolation in backticks
+================================================================================
+
+<?php
+$cmd = 'ls';
+`$cmd`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      (variable_name
+        (name))
+      (string (string_value))))
+  (expression_statement
+    (shell_command_expression
+      (variable_name
+        (name)))))
+
+================================================================================
+Member access expression in backticks
+================================================================================
+
+<?php
+$obj = new stdClass();
+$obj->cmd = 'ls';
+`$obj->cmd`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      (variable_name
+        (name))
+      (object_creation_expression
+        (name)
+        (arguments))))
+  (expression_statement
+    (assignment_expression
+      (member_access_expression
+        (variable_name
+          (name))
+        (name))
+      (string (string_value))))
+  (expression_statement
+    (shell_command_expression
+      (member_access_expression
+        (variable_name
+          (name))
+        (name)))))
+
+================================================================================
+Array subscript expression in backticks
+================================================================================
+
+<?php
+$cmd = array('ls');
+`$cmd[0]`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      (variable_name
+        (name))
+      (array_creation_expression
+        (array_element_initializer
+          (string (string_value))))))
+  (expression_statement
+    (shell_command_expression
+      (subscript_expression
+        (variable_name
+          (name))
+        (integer)))))
+
+================================================================================
+Complex interpolation in backticks
+================================================================================
+
+<?php
+$cmd = 'ls';
+`{$cmd}`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      (variable_name
+        (name))
+      (string (string_value))))
+  (expression_statement
+    (shell_command_expression
+      (variable_name
+        (name)))))
+
+================================================================================
+Nesting of expression in backticks
+================================================================================
+
+<?php
+`echo {` && `echo }`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (binary_expression
+      (shell_command_expression
+        (string_value))
+      (shell_command_expression
+        (string_value)))))
+
+================================================================================
+Nested escaped backticks
+================================================================================
+
+<?php
+`\`echo ls\``;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (shell_command_expression
+      (escape_sequence)
+      (string_value)
+      (escape_sequence))))
+
+================================================================================
+Comment in backticks
+================================================================================
+
+<?php
+`echo /* hello */`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (php_tag)
+  (expression_statement
+    (shell_command_expression
+      (string_value))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -105,5 +105,5 @@ Shell command
 
 (program
   (php_tag)
-  (expression_statement (shell_command_expression))
-  (expression_statement (shell_command_expression)))
+  (expression_statement (shell_command_expression (string_value)))
+  (expression_statement (shell_command_expression (string_value))))


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature (thanks to @Sjord)
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2554, PR: 2584)
