### PR TITLE
Fixes #148 by updating some highlight definitions around function and string

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -17,7 +17,7 @@
   name: (name) @function.method)
 
 (function_call_expression
-  function: (qualified_name (name)) @function)
+  function: [(qualified_name (name)) (name)] @function)
 
 (scoped_call_expression
   name: (name) @function)
@@ -54,9 +54,14 @@
 (variable_name) @variable
 
 ; Basic tokens
-
-(string) @string
-(heredoc) @string
+[
+  (string)
+  (string_value)
+  (encapsed_string)
+  (heredoc)
+  (heredoc_body)
+  (nowdoc_body)
+] @string
 (boolean) @constant.builtin
 (null) @constant.builtin
 (integer) @number

--- a/test/highlight/literals.php
+++ b/test/highlight/literals.php
@@ -3,7 +3,7 @@
 
 echo <<<OMG
   something
-OMG
+OMG;
 // <- string
 
 echo true, TRUE, false, FALSE


### PR DESCRIPTION
There's still a lot of work required to make the highlight queries very good



Checklist:
- [ ] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (no change)
