### PR TITLE
Fixes #147: __DIR__ ignored by highlighting

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -44,6 +44,8 @@
 
 ((name) @constant
  (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))
+((name) @constant.builtin
+ (#match? @constant.builtin "^__[A-Z][A-Z\d_]+__$"))
 
 ((name) @constructor
  (#match? @constructor "^[A-Z]"))

--- a/test/highlight/literals.php
+++ b/test/highlight/literals.php
@@ -14,3 +14,6 @@ echo true, TRUE, false, FALSE
 
 echo PI_314
 //   ^ constant
+
+echo __DIR__
+//    ^ constant.builtin


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (0 rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (no change)
