### PR TITLE
Add support for readonly class_declaration

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -290,7 +290,7 @@ module.exports = grammar({
 
     class_declaration: $ => prec.right(seq(
       optional(field('attributes', $.attribute_list)),
-      optional(field('modifier', choice($.final_modifier, $.abstract_modifier))),
+      optional(field('modifier', choice($.final_modifier, $.abstract_modifier, $.readonly_modifier))),
       keyword('class'),
       field('name', $.name),
       optional($.base_clause),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1190,6 +1190,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "abstract_modifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "readonly_modifier"
                     }
                   ]
                 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1360,6 +1360,10 @@
           {
             "type": "final_modifier",
             "named": true
+          },
+          {
+            "type": "readonly_modifier",
+            "named": true
           }
         ]
       },

--- a/test/corpus/class.txt
+++ b/test/corpus/class.txt
@@ -768,3 +768,23 @@ class Point {
             type: (union_type (primitive_type))
             name: (variable_name (name))))
         body: (compound_statement)))))
+
+=========================================
+Readonly class
+=========================================
+
+<?php
+
+readonly class Test {
+}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    (readonly_modifier)
+    (name)
+    (declaration_list)
+  )
+)


### PR DESCRIPTION
Ref: #139

Checklist:
- [x] All tests pass in CI
- [ ] There are sufficient tests for the new fix/feature
- [ ] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [ ] The conflicts section hasn't grown too much (x new conflicts)
- [ ] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
