### PR TITLE
Fix empty match block parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -763,7 +763,7 @@ module.exports = grammar({
     match_block: $ => prec.left(
       seq(
         '{',
-        commaSep1(
+        commaSep(
           choice(
             $.match_conditional_expression,
             $.match_default_expression

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3959,45 +3959,53 @@
             "value": "{"
           },
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
+                "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "match_conditional_expression"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "match_conditional_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "match_default_expression"
+                      }
+                    ]
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "match_default_expression"
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "match_conditional_expression"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "match_default_expression"
+                            }
+                          ]
+                        }
+                      ]
+                    }
                   }
                 ]
               },
               {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "match_conditional_expression"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "match_default_expression"
-                        }
-                      ]
-                    }
-                  ]
-                }
+                "type": "BLANK"
               }
             ]
           },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2586,7 +2586,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "match_conditional_expression",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1533,3 +1533,28 @@ class A {
     )
   )
 )
+
+===============================================
+Empty match expressions
+===============================================
+
+<?php
+
+$statement = match ($a) {
+};
+
+---
+
+ (program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      (variable_name (name))
+      (match_expression
+        (parenthesized_expression (variable_name (name)))
+        (match_block)
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
Fixes: #157



Checklist:
- [x] All tests pass in CI
- [ ] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [ ] The conflicts section hasn't grown too much (x new conflicts)
- [ ] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
