### PR TITLE
Add support for `true` as a primitive type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">= 0.19, < 0.21"
+tree-sitter = ">= 0.20, < 0.21"
 
 [build-dependencies]
 cc = "1.0"

--- a/grammar.js
+++ b/grammar.js
@@ -520,8 +520,9 @@ module.exports = grammar({
       'void',
       'mixed',
       'static', // only legal as a return type
-      'false', // only legal in unions
-      'null', // only legal in unions
+      'false',
+      'null',
+      'true',
     ),
 
     cast_type: $ => choice(

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "nan": "^2.14.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.1",
+    "tree-sitter-cli": "^0.20.0",
     "shelljs": "^0.8.4"
   },
   "scripts": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2682,6 +2682,10 @@
         {
           "type": "STRING",
           "value": "null"
+        },
+        {
+          "type": "STRING",
+          "value": "true"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5373,11 +5373,11 @@
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "fn",
@@ -5565,6 +5565,10 @@
   },
   {
     "type": "trait",
+    "named": false
+  },
+  {
+    "type": "true",
     "named": false
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -249,3 +249,127 @@ function a(string $var) : static {
     (compound_statement)
   )
 )
+
+===============================================
+Null type
+===============================================
+
+<?php
+
+class Nil {
+    public null $nil = null;
+ 
+    public function foo(null $v): null { }
+}
+
+---
+
+ (program
+  (php_tag)
+  (class_declaration
+    (name)
+    (declaration_list
+      (property_declaration
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))
+          (property_initializer
+            (null))))
+      (method_declaration
+        (visibility_modifier)
+        (name)
+        (formal_parameters
+          (simple_parameter
+            (union_type
+              (primitive_type))
+            (variable_name
+              (name))))
+        (union_type
+          (primitive_type))
+        (compound_statement)))))
+
+===============================================
+False type
+===============================================
+
+<?php
+
+class Falsy {
+    public false $nil = false;
+ 
+    public function foo(false $v): false { }
+}
+
+---
+
+ (program
+  (php_tag)
+  (class_declaration
+    (name)
+    (declaration_list
+      (property_declaration
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))
+          (property_initializer
+            (boolean))))
+      (method_declaration
+        (visibility_modifier)
+        (name)
+        (formal_parameters
+          (simple_parameter
+            (union_type
+              (primitive_type))
+            (variable_name
+              (name))))
+        (union_type
+          (primitive_type))
+        (compound_statement)))))
+
+===============================================
+True type
+===============================================
+
+<?php
+
+class Truthy {
+    public true $truthy = true;
+ 
+    public function foo(true $v): true {}
+}
+
+---
+
+ (program
+  (php_tag)
+  (class_declaration
+    (name)
+    (declaration_list
+      (property_declaration
+        (visibility_modifier)
+        (union_type
+          (primitive_type))
+        (property_element
+          (variable_name
+            (name))
+          (property_initializer
+            (boolean))))
+      (method_declaration
+        (visibility_modifier)
+        (name)
+        (formal_parameters
+          (simple_parameter
+            (union_type
+              (primitive_type))
+            (variable_name
+              (name))))
+        (union_type
+          (primitive_type))
+        (compound_statement)))))
+


### PR DESCRIPTION
This commit introduce the new php8.2 `true` primitive type; It also adds tests to validate that `null` and `false` are treated as standalone type as described in this RFC: https://wiki.php.net/rfc/null-false-standalone-types

Ref: #139
See: https://wiki.php.net/rfc/true-type, https://wiki.php.net/rfc/null-false-standalone-types



Checklist:
- [ ] All tests pass in CI
- [ ] There are sufficient tests for the new fix/feature
- [ ] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [ ] The conflicts section hasn't grown too much (x new conflicts)
- [ ] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
