### PR TITLE
Only allow int and string as backed enum type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -263,7 +263,7 @@ module.exports = grammar({
       optional(field('attributes', $.attribute_list)),
       keyword('enum'),
       field('name', $.name),
-      optional(seq(':', $._type)),
+      optional(seq(':', alias(choice('string', 'int'), $.primitive_type))),
       optional($.class_interface_clause),
       field('body', $.enum_declaration_list)
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1006,8 +1006,22 @@
                     "value": ":"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_type"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "string"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "int"
+                        }
+                      ]
+                    },
+                    "named": true,
+                    "value": "primitive_type"
                   }
                 ]
               },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1885,11 +1885,11 @@
       "required": false,
       "types": [
         {
-          "type": "_type",
+          "type": "class_interface_clause",
           "named": true
         },
         {
-          "type": "class_interface_clause",
+          "type": "primitive_type",
           "named": true
         }
       ]

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -655,13 +655,13 @@ enum Suit: string
   )
   (enum_declaration
     (name)
-    (union_type (primitive_type))
+    (primitive_type)
     (class_interface_clause (name))
     (enum_declaration_list)
   )
   (enum_declaration
     (name)
-    (union_type (primitive_type))
+    (primitive_type)
     (enum_declaration_list 
       (enum_case (name) (string (string_value)))
       (enum_case (name))


### PR DESCRIPTION
As documented [here](https://www.php.net/manual/en/language.enumerations.backed.php) the scalar equivalent of backed enums can only be `string` or `int`.



Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2588, PR: 2588) 