### PR TITLE
Add additional match queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,5 +1,19 @@
+(namespace_definition
+  name: (namespace_name) @name) @module
+
+(interface_declaration
+  name: (name) @name) @definition.interface
+
+(trait_declaration
+  name: (name) @name) @definition.interface
+
 (class_declaration
   name: (name) @name) @definition.class
+
+(class_interface_clause [(name) (qualified_name)] @name) @impl
+
+(property_declaration
+  (property_element (variable_name (name) @name))) @definition.field
 
 (function_definition
   name: (name) @name) @definition.function


### PR DESCRIPTION
This patch upstreams a few match queries used to extract symbols from `tree-sitter-php` parse trees used within GitHub.  All existing tag queries are untouched.

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (x new conflicts) (no change to grammar / conflicts)
- [x] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c) -- no change to parser
