### PR TITLE
Remove invalid `$._intrinsic` reference

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -87,7 +87,6 @@ module.exports = grammar({
     $._callable_expression,
     $._foreach_value,
     $._literal,
-    $._intrinsic,
     $._class_type_designator,
     $._variable_name,
   ],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8927,7 +8927,6 @@
     "_callable_expression",
     "_foreach_value",
     "_literal",
-    "ReferenceError",
     "_class_type_designator",
     "_variable_name"
   ],


### PR DESCRIPTION
Dangling invalid references will be prohibited in Tree-sitter soon, this PR removes them because this repo is a tree-sitter dependency for corpus tests and it breaks tests in the tree-sitter main repo.

_Tree-sitter error reports:_

```
[stdin]:350
      if (symbol.constructor == ReferenceError) throw symbol;
                                                ^

ReferenceError: Undefined rule: '_intrinsic'
    at Object.get ([stdin]:209:23)
    at Proxy.inline (.../tree-sitter/test/fixtures/grammars/php/grammar.js:90:7)
    at grammar ([stdin]:343:40)
    at Object.<anonymous> (.../tree-sitter/test/fixtures/grammars/php/grammar.js:32:18)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18) {
  symbol: { type: 'SYMBOL', name: '_intrinsic' }
}

Node.js v18.14.2
Can't load a grammar.js file

Caused by:
    Node process exited with status 1
```

