### PR TITLE
fix warnings in scanner.cs

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -170,7 +170,7 @@ struct Scanner {
 
     bool end_tag_matched = false;
 
-    for (int i = 0; i < heredoc_tag.length(); i++) {
+    for (size_t i = 0; i < heredoc_tag.length(); i++) {
       if (lexer->lookahead != heredoc_tag[i]) break;
       advance(lexer);
       has_consumed_content = true;
@@ -224,7 +224,7 @@ struct Scanner {
 
       bool end_tag_matched = false;
 
-      for (int i = 0; i < heredoc_tag.length(); i++) {
+      for (size_t i = 0; i < heredoc_tag.length(); i++) {
         if (lexer->lookahead != heredoc_tag[i]) break;
         has_consumed_content = true;
         advance(lexer);
@@ -313,6 +313,7 @@ struct Scanner {
             }
             break;
           }
+	  break;
         case '[':
           if (is_after_variable) {
             return has_content;


### PR DESCRIPTION
use t_size in for statements to match type
add missing break in case statement

Checklist:
- [ ] All tests pass in CI
- [ ] There are sufficient tests for the new fix/feature
- [ ] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [ ] The conflicts section hasn't grown too much (x new conflicts)
- [ ] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
