### PR TITLE
Remove extra whitespace from `heredoc_end`

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -158,7 +158,7 @@ struct Scanner {
     if (open_heredocs.empty()) {
       return false;
     }
-      
+
     // While PHP requires the nowdoc end tag to be the very first on a new line, there may be an
     // arbitrary amount of whitespace before the closing token
     while (iswspace(lexer->lookahead)) {
@@ -343,7 +343,7 @@ struct Scanner {
       result += lexer->lookahead;
       advance(lexer);
     }
-  
+
     return result;
   }
 
@@ -402,7 +402,7 @@ struct Scanner {
       Heredoc heredoc = open_heredocs.back();
 
       while (iswspace(lexer->lookahead)) {
-        advance(lexer);
+        skip(lexer);
       }
 
       if (heredoc.word != scan_heredoc_word(lexer)) {


### PR DESCRIPTION
Hello!

Please see https://github.com/nvim-treesitter/nvim-treesitter/issues/4333 for reference, the `heredoc_end` rule includes whitespace---this PR removes that whitespace so the `heredoc_end` is just the identifier.

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (x new conflicts)
- [x] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)


