### PR TITLE
fix parse error with `final` or `abstract` `readonly` classes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -284,7 +284,8 @@ module.exports = grammar({
 
     class_declaration: $ => prec.right(seq(
       optional(field('attributes', $.attribute_list)),
-      optional(field('modifier', choice($.final_modifier, $.abstract_modifier, $.readonly_modifier))),
+      optional(field('modifier', choice($.final_modifier, $.abstract_modifier))),
+      optional(field('modifier', $.readonly_modifier)),
       keyword('class'),
       field('name', $.name),
       optional($.base_clause),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1220,12 +1220,24 @@
                     {
                       "type": "SYMBOL",
                       "name": "abstract_modifier"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "readonly_modifier"
                     }
                   ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "modifier",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "readonly_modifier"
                 }
               },
               {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1350,7 +1350,7 @@
         ]
       },
       "modifier": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
           {

--- a/test/corpus/class.txt
+++ b/test/corpus/class.txt
@@ -778,6 +778,9 @@ Readonly class
 readonly class Test {
 }
 
+final readonly class Test2 {
+}
+
 ---
 
 (program
@@ -785,9 +788,12 @@ readonly class Test {
   (class_declaration
     (readonly_modifier)
     (name)
-    (declaration_list)
-  )
-)
+    (declaration_list))
+  (class_declaration
+    (final_modifier)
+    (readonly_modifier)
+    (name)
+    (declaration_list)))
 
 =========================================
 Constants in trait


### PR DESCRIPTION
`final readonly` and `abstract class` are allowed in php but the tree-sitter parser throw an error.

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (x new conflicts)
- [x] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
