### PR TITLE
feat: allows attributes on promoted properties

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -451,6 +451,7 @@ module.exports = grammar({
     ),
 
     property_promotion_parameter: $ => seq(
+      optional(field('attributes', $.attribute_list)),
       field('visibility', $.visibility_modifier),
       field('readonly', optional($.readonly_modifier)),
       field('type', optional($._type)), // Note: callable is not a valid type here, but instead of complicating the parser, we defer this checking to any intelligence using the parser

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2334,6 +2334,22 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "attributes",
+              "content": {
+                "type": "SYMBOL",
+                "name": "attribute_list"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "FIELD",
           "name": "visibility",
           "content": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3767,6 +3767,16 @@
     "type": "property_promotion_parameter",
     "named": true,
     "fields": {
+      "attributes": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "attribute_list",
+            "named": true
+          }
+        ]
+      },
       "default_value": {
         "multiple": false,
         "required": false,

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -373,6 +373,14 @@ class A {
 function a() {
 }
 
+class B {
+  public function __construct(
+    #[A]
+    public string $a,
+  ) {
+  }
+}
+
 ---
 
 (program
@@ -605,7 +613,25 @@ function a() {
     )
     name: (name)
     parameters: (formal_parameters)
-    body: (compound_statement)
+    body: (compound_statement))
+    (class_declaration
+      name: (name)
+      body: (declaration_list
+        (method_declaration
+          (visibility_modifier)
+          name: (name)
+          parameters: (formal_parameters
+            (property_promotion_parameter
+              attributes: (attribute_list
+                (attribute_group
+                  (attribute
+                    (name))))
+              visibility: (visibility_modifier)
+              type: (union_type
+                (primitive_type))
+              name: (variable_name
+                (name))))
+          body: (compound_statement)))
   )
 )
 


### PR DESCRIPTION
This commit will correctly parse attributes on promoted properties.

This syntax is allowed and not recognize by this parser :

```php
<?php

class B {
  public function __construct(
    #[A]
    public string $a,
  ) {
  }
}
```

Checklist:
- [x] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (0 new conflicts)
- [x] The parser size hasn't grown too much (master: 2642, PR: 2658) 
