### PR TITLE
chore: Add license to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["incremental", "parsing", "php"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-php"
 edition = "2018"
+license = "MIT"
 
 build = "bindings/rust/build.rs"
 include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]


### PR DESCRIPTION
This package cannot be published to crates.io without it.



Checklist:
- [ ] All tests pass in CI
- [ ] There are sufficient tests for the new fix/feature
- [ ] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [ ] The conflicts section hasn't grown too much (x new conflicts)
- [ ] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
