### PR TITLE
Allow Trailing Comma In `match_expression_list`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -771,7 +771,7 @@ module.exports = grammar({
       )
     ),
 
-    match_condition_list: $ => commaSep1($._expression),
+    match_condition_list: $ => seq(commaSep1($._expression), optional(',')),
 
     match_conditional_expression: $ => seq(
       field('conditional_expressions', $.match_condition_list),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4150,24 +4150,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1053,6 +1053,7 @@ Match expressions
 
 $statement = match ($a) {
     Lexer::T_SELECT, $c => $b,
+    Lexer::FOO, $c, => $b,
     Lexer::T_UPDATE => updateStatement(),
     Lexer::T_DELETE => $this->DeleteStatement(),
     default => $this->syntaxError('SELECT, UPDATE or DELETE'),
@@ -1068,6 +1069,16 @@ $statement = match ($a) {
       (match_expression
         (parenthesized_expression (variable_name (name)))
         (match_block
+          (match_conditional_expression
+            (match_condition_list
+              (class_constant_access_expression
+                (name)
+                (name)
+              )
+              (variable_name (name))
+            )
+            (variable_name (name))
+          )
           (match_conditional_expression
             (match_condition_list
               (class_constant_access_expression


### PR DESCRIPTION

... It's valid PHP, apparently.

```shell
php -r 'echo match ("Hello") {
        "Hi", "Hello", => true,
        "Bye", => false,
};'
```

Checklist:
- [ ] All tests pass in CI
- [x] There are sufficient tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [x] The conflicts section hasn't grown too much (x new conflicts)
- [x] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT) (check the value of STATE_COUNT in src/parser.c)
