### PR TITLE
Use python 3.12 and update node-gyp to 10.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
       - run: npm install
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "eslint": ">=8.54.0",
     "eslint-config-google": "^0.14.0",
+    "node-gyp": "^10.0.1",
     "shelljs": "^0.8.5",
     "tree-sitter-cli": "^0.20.8"
   },


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'distutils'` in macos github action run.

# Checklist

- [x] All tests pass in CI
- [X] There are enough tests for the new fix/feature
- [X] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [X] The conflicts section hasn't grown too much (x new conflicts)
- [X] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT)
      (check the value of STATE_COUNT in src/parser.c)
