### PR TITLE
Replace stdlib calls: isxdigit -> iswxdigit, wcscmp -> memcmp

### DIFF
--- a/common/scanner.h
+++ b/common/scanner.h
@@ -92,6 +92,13 @@ static String string_new() {
     return (String){.cap = 16, .len = 0, .data = calloc(17, sizeof(wchar_t))};
 }
 
+static inline bool string_eq(String *self, String *other)  {
+    if (self->len != other->len) {
+        return false;
+    }
+    return memcmp(self->data, other->data, self->len * sizeof(self->data[0])) == 0;
+}
+
 typedef struct {
     String word;
     bool end_word_indentation_allowed;
@@ -204,7 +211,7 @@ static inline bool is_escapable_sequence(TSLexer *lexer) {
     // Hex
     if (letter == 'x') {
         advance(lexer);
-        return isxdigit(lexer->lookahead);
+        return iswxdigit(lexer->lookahead);
     }
 
     // Unicode
@@ -506,7 +513,7 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
         }
 
         String word = scan_heredoc_word(lexer);
-        if (wcscmp(word.data, heredoc.word.data) != 0) {
+        if (!string_eq(&word, &heredoc.word)) {
             STRING_FREE(word);
             return false;
         }


### PR DESCRIPTION
This PR change the external scanner to use the standard set of libc functions defined in https://github.com/tree-sitter/tree-sitter/pull/2897, which will make it possible to consume these parsers as WASM files.

# Checklist

- [ ] All tests pass in CI
- [ ] There are enough tests for the new fix/feature
- [ ] Grammar rules have not been renamed unless absolutely necessary (x rules renamed)
- [ ] The conflicts section hasn't grown too much (x new conflicts)
- [ ] The parser size hasn't grown too much (master: STATE_COUNT, PR: STATE_COUNT)
      (check the value of STATE_COUNT in src/parser.c)
