### PR TITLE
Add `self` keyword

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -115,6 +115,7 @@
 "require_once" @keyword
 "require" @keyword
 "return" @keyword
+"self" @keyword
 "static" @keyword
 "switch" @keyword
 "throw" @keyword


### PR DESCRIPTION
I was trying out the Zed IDE and noticed the `self` keyword (which behaves similarly to `static`) wasn't highlighted. I have no idea what I'm doing, but it looks like this one line change is enough?