### PR TITLE
feat: use the new reserved rules api

### DIFF
--- a/php/src/grammar.json
+++ b/php/src/grammar.json
@@ -1501,42 +1501,46 @@
       }
     },
     "property_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_name"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "FIELD",
-                  "name": "default_value",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "expression"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
+      "type": "RESERVED",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_name"
             }
-          ]
-        }
-      ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "default_value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      },
+      "context_name": "properties"
     },
     "property_hook_list": {
       "type": "SEQ",
@@ -1700,8 +1704,12 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "_function_definition_header"
+          "type": "RESERVED",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_function_definition_header"
+          },
+          "context_name": "properties"
         },
         {
           "type": "CHOICE",
@@ -2588,90 +2596,94 @@
       ]
     },
     "simple_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "attributes",
-              "content": {
-                "type": "SYMBOL",
-                "name": "attribute_list"
-              }
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
+      "type": "RESERVED",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type"
+                "type": "FIELD",
+                "name": "attributes",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "attribute_list"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "type",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "reference_modifier",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "reference_modifier"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_name"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "default_value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
               }
             ]
           }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "reference_modifier",
-              "content": {
-                "type": "SYMBOL",
-                "name": "reference_modifier"
-              }
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_name"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "FIELD",
-                  "name": "default_value",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "expression"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+        ]
+      },
+      "context_name": "properties"
     },
     "variadic_parameter": {
       "type": "SEQ",
@@ -2777,17 +2789,21 @@
       ]
     },
     "named_type": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "name"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "qualified_name"
-        }
-      ]
+      "type": "RESERVED",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "name"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "qualified_name"
+          }
+        ]
+      },
+      "context_name": "types"
     },
     "optional_type": {
       "type": "SEQ",
@@ -3092,21 +3108,25 @@
       ]
     },
     "const_element": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_identifier"
-        },
-        {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "SYMBOL",
-          "name": "expression"
-        }
-      ]
+      "type": "RESERVED",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_identifier"
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          },
+          {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        ]
+      },
+      "context_name": "constants"
     },
     "echo_statement": {
       "type": "SEQ",
@@ -5013,48 +5033,52 @@
       ]
     },
     "class_constant_access_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_scope_resolution_qualifier"
-        },
-        {
-          "type": "STRING",
-          "value": "::"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_identifier"
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "{"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "expression"
+      "type": "RESERVED",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_scope_resolution_qualifier"
+          },
+          {
+            "type": "STRING",
+            "value": "::"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "{"
                   },
-                  "named": true,
-                  "value": "name"
-                },
-                {
-                  "type": "STRING",
-                  "value": "}"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    },
+                    "named": true,
+                    "value": "name"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "context_name": "constants"
     },
     "print_intrinsic": {
       "type": "SEQ",
@@ -6391,84 +6415,88 @@
       ]
     },
     "_argument_name": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "ALIAS",
+      "type": "RESERVED",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "name"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "array",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "fn",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "function",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "match",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "namespace",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "null",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "static",
-                  "flags": "i"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "throw",
-                  "flags": "i"
-                },
-                {
-                  "type": "STRING",
-                  "value": "parent"
-                },
-                {
-                  "type": "STRING",
-                  "value": "self"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "true|false",
-                  "flags": "i"
-                }
-              ]
-            },
-            "named": true,
-            "value": "name"
+              "type": "ALIAS",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "name"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "array",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "fn",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "function",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "match",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "namespace",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "null",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "static",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "throw",
+                    "flags": "i"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "parent"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "self"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "true|false",
+                    "flags": "i"
+                  }
+                ]
+              },
+              "named": true,
+              "value": "name"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ":"
           }
-        },
-        {
-          "type": "STRING",
-          "value": ":"
-        }
-      ]
+        ]
+      },
+      "context_name": "properties"
     },
     "member_call_expression": {
       "type": "PREC",
@@ -7848,8 +7876,12 @@
           "value": "$"
         },
         {
-          "type": "SYMBOL",
-          "name": "name"
+          "type": "RESERVED",
+          "content": {
+            "type": "SYMBOL",
+            "name": "name"
+          },
+          "context_name": "variables"
         }
       ]
     },
@@ -9271,5 +9303,926 @@
     "primary_expression",
     "type",
     "literal"
-  ]
+  ],
+  "reserved": {
+    "global": [
+      {
+        "type": "PATTERN",
+        "value": "abstract",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "and",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "as",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "break",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "callable",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "case",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "catch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "class",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "clone",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "const",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "continue",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "declare",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "default",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "do",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "echo",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "else",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "elseif",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "enddeclare",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endfor",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endforeach",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endif",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endswitch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endwhile",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "extends",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "final",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "finally",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "fn",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "for",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "foreach",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "function",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "global",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "goto",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "if",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "implements",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "include",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "include_once",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "instanceof",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "insteadof",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "interface",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "match",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "namespace",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "new",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "or",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "print",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "private",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "protected",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "public",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "readonly",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "require",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "require_once",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "return",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "switch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "throw",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "trait",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "try",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "use",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "while",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "xor",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "yield",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "static",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "var",
+        "flags": "i"
+      }
+    ],
+    "variables": [
+      {
+        "type": "PATTERN",
+        "value": "abstract",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "and",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "as",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "break",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "callable",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "case",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "catch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "class",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "clone",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "const",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "continue",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "declare",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "default",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "do",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "echo",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "else",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "elseif",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "enddeclare",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endfor",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endforeach",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endif",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endswitch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endwhile",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "extends",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "final",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "finally",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "fn",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "for",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "foreach",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "function",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "global",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "goto",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "if",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "implements",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "include",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "include_once",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "instanceof",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "insteadof",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "interface",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "match",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "namespace",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "new",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "or",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "print",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "private",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "protected",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "public",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "readonly",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "require",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "require_once",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "return",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "switch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "throw",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "trait",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "try",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "use",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "while",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "xor",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "yield",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "static",
+        "flags": "i"
+      }
+    ],
+    "types": [
+      {
+        "type": "PATTERN",
+        "value": "abstract",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "and",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "as",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "break",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "callable",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "case",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "catch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "class",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "clone",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "const",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "continue",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "declare",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "default",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "do",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "echo",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "else",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "elseif",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "enddeclare",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endfor",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endforeach",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endif",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endswitch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "endwhile",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "extends",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "final",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "finally",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "fn",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "for",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "foreach",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "function",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "global",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "goto",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "if",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "implements",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "include",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "include_once",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "instanceof",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "insteadof",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "interface",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "match",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "namespace",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "new",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "or",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "print",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "private",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "protected",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "public",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "readonly",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "require",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "require_once",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "return",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "switch",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "throw",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "trait",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "try",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "use",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "while",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "xor",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "yield",
+        "flags": "i"
+      },
+      {
+        "type": "PATTERN",
+        "value": "var",
+        "flags": "i"
+      }
+    ],
+    "constants": [
+      {
+        "type": "PATTERN",
+        "value": "class",
+        "flags": "i"
+      }
+    ],
+    "properties": []
+  }
 }

--- a/php/src/tree_sitter/array.h
+++ b/php/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/php/src/tree_sitter/parser.h
+++ b/php/src/tree_sitter/parser.h
@@ -79,6 +79,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -115,7 +121,7 @@ struct TSLanguage {
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,6 +135,9 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
 };
 
 static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -1,0 +1,44 @@
+=================================================
+Error detected at globally reserved keyword
+=================================================
+
+<?php
+$object->
+class Test {  // 'class' should not be treated as a property
+}
+
+class Example {
+    public function test() {
+        $this->    // incomplete
+        function process() {}  // function should be recognized
+    }
+}
+
+---
+
+(program
+  (php_tag)
+  (ERROR
+    (variable_name
+      (name)))
+  (class_declaration
+    (name)
+    (declaration_list
+      (comment)))
+  (class_declaration
+    (name)
+    (declaration_list
+      (method_declaration
+        (visibility_modifier)
+        (name)
+        (formal_parameters)
+        (compound_statement
+          (ERROR
+            (variable_name
+              (name)))
+          (comment)
+          (function_definition
+            (name)
+            (formal_parameters)
+            (compound_statement))
+          (comment))))))


### PR DESCRIPTION
⚠️ Needs https://github.com/tree-sitter/tree-sitter/pull/3896 ⚠️

@calebdw you probably know PHP better than me, it'd be nice if you can audit this, but so far from what I can tell everything in the corpus parses as it should, and we have much better error recovery in a variety of cases, I just put 2 in a test (compare with error recovery w/o this PR to see a staggering difference :) )