### PR TITLE
Include LICENSE file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "common",
   "bindings/rust",
   "php/grammar.js",


### PR DESCRIPTION
This is needed by the MIT license terms

```
❯ cargo package --list | grep LICENSE
LICENSE
```