### PR TITLE
Fix Swift Bindings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     .testTarget(
       name: "TreeSitterPHPTests",
       dependencies: [
-        "SwiftTreeSitter",
+        .product(name: "SwiftTreeSitter", package: "swift-tree-sitter"),
         "TreeSitterPHP",
       ],
       path: "bindings/swift/TreeSitterPHPTests"


### PR DESCRIPTION
The Swift bindings were not updated correctly and fail to resolve this package when using Swift 6.